### PR TITLE
Normalise notebook kernel names

### DIFF
--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -16,6 +16,8 @@ from ruamel.yaml import YAML
 import github3 as gh3
 from github3 import authorize
 
+import nbformat
+
 from . import ok
 from .distribute import find_notebooks, render_circleci_template
 from .notebook import split_notebook

--- a/abcclassroom/notebook.py
+++ b/abcclassroom/notebook.py
@@ -15,6 +15,22 @@ except ImportError:
     raise ImportError('IPython needs to be installed for notebook grading')
 
 
+def normalize_kernel_name(notebook):
+    nb = nbformat.read(notebook, as_version=4)
+
+    kernelspec = nb.metadata.kernelspec
+    if "[conda env:" in kernelspec.display_name:
+        if kernelspec.language == 'python':
+            if nb.metadata.language_info.version.startswith('3.'):
+                kernelspec.name = 'python3'
+                kernelspec.display_name = 'Python 3'
+            else:
+                kernelspec.name = 'python2'
+                kernelspec.display_name = 'Python 2'
+
+        nbformat.write(nb, notebook)
+
+
 def split_notebook(notebook, student_path, autograder_path):
     """Split a master notebook into student and autograder notebooks"""
     print('Processing', notebook)
@@ -35,6 +51,7 @@ def split_notebook(notebook, student_path, autograder_path):
     nb.replace_text(text_replace_begin, text_replace_end)
 
     nb.save(os.path.join(student_path, nb_name))
+    normalize_kernel_name(os.path.join(student_path, nb_name))
 
     # create test files for the autograder
     nb = NotebookCleaner(notebook)


### PR DESCRIPTION
When placing a notebook in the student directory we inspect the kernel
name and re-write names like "Python [conda env:earth-analytics-python]"
to "Python 3". Conda env specific kernels might not be installed on the
student's computers or might have a different name there. This leaves
the instructors notebooks untouched.

For example a notebook like https://github.com/earth-analytics-edu/ea-spring-2019-lwasser/blob/master/week-06/time-series-homework-wk-6.ipynb will be changed when you run `abc-author` into a notebook that has a kernel called "Python 3".

Closes #20 and closes #48