### PR TITLE
dev setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ student/
 .ipynb_checkpoints
 __pycache__
 *.egg-info
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.6

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,46 @@
+Get Started!
+============
+
+Ready to contribute? Here's how to set up EarthPy for local development.
+
+1. Fork the repository on GitHub
+--------------------------------
+
+To create your own copy of the repository on GitHub, navigate to the
+`earthlab/abc-classroom <https://github.com/earthlab/abc-classroom>`_ repository
+and click the **Fork** button in the top-right corner of the page.
+
+2. Clone your fork locally
+--------------------------
+
+Use ``git clone`` to get a local copy of your EarthPy repository on your
+local filesystem::
+
+    $ git clone git@github.com:your_name_here/abc-classroom.git
+    $ cd abc-classroom/
+
+3. Set up your fork for local development
+-----------------------------------------
+
+Create an environment
+^^^^^^^^^^^^^^^^^^^^^
+
+Using conda, there are two options.
+
+1. The easiest option is to create an environment from the
+``environment.yml`` file.
+Note that this will only allow you to test against one version of python
+locally, but this is the recommended option on Windows and MacOS::
+
+    $ conda env create -f environment.yml
+    $ conda activate abc-dev
+
+Install the package
+^^^^^^^^^^^^^^^^^^^
+
+Once your earthpy-dev environment is activated, install EarthPy in editable
+mode, along with the development requirements and pre-commit hooks::
+
+    $ pip install -e .
+    $ pip install -r dev-requirements.txt
+    $ pre-commit install

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,8 +22,8 @@ local filesystem::
 3. Set up your fork for local development
 -----------------------------------------
 
-Create an environment
-^^^^^^^^^^^^^^^^^^^^^
+Setup the ABC-Classroom Dev Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Using conda, there are two options.
 
@@ -35,12 +35,17 @@ locally, but this is the recommended option on Windows and MacOS::
     $ conda env create -f environment.yml
     $ conda activate abc-dev
 
-Install the package
-^^^^^^^^^^^^^^^^^^^
+Install the package & The Precommit Hook
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once your earthpy-dev environment is activated, install EarthPy in editable
 mode, along with the development requirements and pre-commit hooks::
 
     $ pip install -e .
     $ pip install -r dev-requirements.txt
+
+We are using black to enforce PEP 8 styles. Install the pre-commit once and black
+will run every time you make a commit. Note that you will need to commit any changes
+that black makes to your code after those changes are applied.
+
     $ pre-commit install

--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@
 
 ## Try it!
 
-Run `pip install -e.` in the directory of this README.
+Run `pip install -e .` in the directory of this README.
+
+
+## Dev
+
+
+
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
 sphinx==1.8.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme
+codecov==2.0.15
+bumpversion==0.5.3
+pre-commit==1.18.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: abc-dev
+channels:
+  - conda-forge
+dependencies:
+  # Github API
+  - github3.py
+


### PR DESCRIPTION
I am going to start chipping away at the package structure setting up things like 

* testing infrastructure
* docs and testing infrastructure
* dev environment
* etc

This pr includes

- [x] setup for a dev environment
- [x] install instructions
- [x] setup of black for formatting as a precommit hook

we also will want to push this to conda forge but there is no rush on this. having bumpversion in place however will be ideal for this workflow. 