### PR TITLE
Add changelog to abc-classroom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ config.yml
 docs/api
 scratch-workspace/
 dist/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# abc-classroom Release Notes
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.11]
+* Change tracking started also added basic infrastructure for docs, autodoc, travis-ci testing and sphinx enhancements (@lwasser)
+* In this release some docstrings were updated. (@lwasser) 
+
+Note that this is the beginning of the change log so issues aren't identified here but will be in the future. 


### PR DESCRIPTION
this PR addresses #97 
a small edit to the gitignore to ignore the build dir where the initial pypi release files live was also added! e