### PR TITLE
Update docs with code-of-conduct / change log, remove python 3.5 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ matrix:
   include:
   - os: linux
     dist: xenial
-    python: 3.5
-    env: TOXENV=py35
-  - os: linux
-    dist: xenial
     python: 3.6
     env: TOXENV=py36
   - os: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add code of conduct, and md support (m2r) to build (#126, @lwasser)
+
 
 ## [0.0.11]
 * Change tracking started also added basic infrastructure for docs, autodoc, travis-ci testing and sphinx enhancements (@lwasser)
-* In this release some docstrings were updated. (@lwasser) 
+* In this release some docstrings were updated. (@lwasser)
 
-Note that this is the beginning of the change log so issues aren't identified here but will be in the future. 
+Note that this is the beginning of the change log so issues aren't identified here but will be in the future.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# MatPlotCheck Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at earth.lab@colorado.edu. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# MatPlotCheck Code of Conduct
+# ABC-Classroom Code of Conduct
 
 ## Our Pledge
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+m2r
 sphinx==2.2.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme==0.4.3

--- a/docs/change-log.rst
+++ b/docs/change-log.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../CHANGELOG.md

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../CODE_OF_CONDUCT.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@
 
 project = "abc-classroom"
 copyright = "2019, Earth Lab"
-author = "Leah Wasser, Tim Head"
+author = "Leah Wasser, Karen Kranston"
 
 # The short X.Y version
 version = "0.0.11"
@@ -39,12 +39,14 @@ release = "0.0.11"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "m2r",  # Markdown sphinx docs support
+    "sphinx.ext.napoleon",  # numpy style doc strings for autodoc
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
-    "sphinx.ext.todo",
+    # "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
-    "sphinx.ext.ifconfig",
+    # "sphinx.ext.mathjax",
+    # "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
 ]
 
@@ -54,8 +56,8 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = [".rst", ".md"]
+# source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@
 
 project = "abc-classroom"
 copyright = "2019, Earth Lab"
-author = "Leah Wasser, Karen Kranston"
+author = "Leah Wasser, Karen Cranston"
 
 # The short X.Y version
 version = "0.0.11"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to abc-classroom's documentation!
    api
    github
    contributing
+   code-of-conduct
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to abc-classroom's documentation!
    github
    contributing
    code-of-conduct
+   change-log
 
 
 


### PR DESCRIPTION
* add m2r to build to support md docs
* add code of conduct to RTD
* update gitignore 
* remove python 3.5 build from travis

this addresses #96  and #97 