### PR TITLE
Assignment management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.0.12]
+* Change template functionality so that assignment name provided by user is not modified by abc-classroom (no longer add coursename as prefix) (@kcranston, #137)
+* Add each new assignment to an `assignments` section of the config (@kcranston, #138)
 * Fix config.yml to ensure ``gitignore`` file has a period at the beginning, update docs (@lwasser, #124)
 * Add assignment template functionality (@kcranston, #105)
 * Fix RTD build to ensure API reference and other docs build properly (#113, #114, @lwasser)

--- a/abcclassroom/config.py
+++ b/abcclassroom/config.py
@@ -67,8 +67,9 @@ def get_config(configpath=None):
             config = yaml.load(f)
         return config
     except FileNotFoundError as err:
+        configpath.resolve()
         print(
-            "Oops! I can't seem to find a config.yml file in {}. "
+            "Oops! I can't seem to find a config.yml file at {}. "
             "Are you in the top-level directory for the course? If you don't have a course directory and config file "
             "setup yet, you can create one using abc-quickstart"
             ".\n".format(configpath)
@@ -82,6 +83,7 @@ def write_config(config, configpath=None):
         configpath = Path("config.yml")
     else:
         configpath = Path(configpath, "config.yml")
+    print("Writing config to {}".format(configpath))
     with open(configpath, "w") as f:
         yaml.dump(config, f)
 
@@ -117,12 +119,11 @@ def set_config_option(
     existing_value = get_config_option(config, option, required=False)
     if append_value == True and existing_value is not None:
         if isinstance(existing_value, list):
-            print("appending {} to {}".format(value, existing_value))
             existing_value.append(value)
             value = existing_value
-            print("new value is {}".format(value))
         else:
             value = [existing_value, value]
     config[option] = value
+    print("Writing new config at {}".format(configpath))
     write_config(config, configpath)
     return config

--- a/abcclassroom/config.py
+++ b/abcclassroom/config.py
@@ -6,7 +6,7 @@ abc-classroom.config
 
 import os
 import sys
-
+from pathlib import Path
 import os.path as op
 
 from ruamel.yaml import YAML
@@ -56,20 +56,34 @@ def set_github_auth(auth_info):
         yaml.dump(config, f)
 
 
-def get_config():
+def get_config(configpath=None):
     yaml = YAML()
     try:
-        with open("config.yml") as f:
+        if configpath is None:
+            configpath = Path("config.yml")
+        else:
+            configpath = Path(configpath, "config.yml")
+        with open(configpath) as f:
             config = yaml.load(f)
         return config
     except FileNotFoundError as err:
         print(
-            "Oops! I can't seem to find a config.yml file in this "
-            "directory. Are you in the top-level directory for the course? If you don't have a course directory and config file "
+            "Oops! I can't seem to find a config.yml file in {}. "
+            "Are you in the top-level directory for the course? If you don't have a course directory and config file "
             "setup yet, you can create one using abc-quickstart"
-            ".\n"
+            ".\n".format(configpath)
         )
         sys.exit(1)
+
+
+def write_config(config, configpath=None):
+    yaml = YAML()
+    if configpath is None:
+        configpath = Path("config.yml")
+    else:
+        configpath = Path(configpath, "config.yml")
+    with open(configpath, "w") as f:
+        yaml.dump(config, f)
 
 
 # TODO: allow for nested gets, e.g. config[a][b]
@@ -84,7 +98,7 @@ def get_config_option(config, option, required=True):
     except KeyError as err:
         if required == True:
             print(
-                "Did not find required option {} in config; exciting".format(
+                "Did not find required option {} in config; exiting".format(
                     option
                 )
             )
@@ -93,7 +107,22 @@ def get_config_option(config, option, required=True):
             return None
 
 
-def set_config(config):
-    yaml = YAML()
-    with open(P("config.yml"), "w") as f:
-        yaml.dump(config, f)
+def set_config_option(
+    config, option, value, append_value=False, configpath=None
+):
+    """
+    Sets a config option. If option already exists and append_value is False, replaces existing value. If option exists and append_value is true, adds new value to list of existing values. Writes the new config (overwriting the existing file) and returns new config dict.
+    """
+
+    existing_value = get_config_option(config, option, required=False)
+    if append_value == True and existing_value is not None:
+        if isinstance(existing_value, list):
+            print("appending {} to {}".format(value, existing_value))
+            existing_value.append(value)
+            value = existing_value
+            print("new value is {}".format(value))
+        else:
+            value = [existing_value, value]
+    config[option] = value
+    write_config(config, configpath)
+    return config

--- a/abcclassroom/example-data/config.yml
+++ b/abcclassroom/example-data/config.yml
@@ -3,23 +3,10 @@
 # Create a new organization on GitHub and change this to the name you gave it
 organization: earth-analytics-edu
 
-# Name of your course. Will be used to prefix repositories inside the
-# organization. The repositories will be named:
-# https://github.com/<organization>/<courseName>-template
-# https://github.com/<organization>/<courseName>-<studentName>
-# or, if short_classname (below) is set:
-# https://github.com/<organization>/<short_classname>-template
-# https://github.com/<organization>/<short_classname>-<studentName>
-course_name: earth-analytics-bootcamp
-
 # Absolute path to the course directory. If you ran abc-quickstart, this was
 # set up for you
 course_directory: /Users/karen/awesome-course
 
-# (Optional) Short name for course. If set, this gets used to prepend
-# the repositories instead of the full course_name, just to make
-# names shorter and less unwieldy
-short_coursename: ea
 
 # Path to the course roster (list of students downloaded from
 # github classroom). If the roster is in the course_directory, simply enter
@@ -35,7 +22,6 @@ nbgrader_dir: nbgrader
 # Assumed to be relative to course_dir unless you enter an absolute path (i.e. starting with '/' on Linux or OS X or with 'C:' on Windows). None of the
 # parent directories should be git repositories.
 clone_dir: /Users/me/awesome-course/cloned_dirs
-
 
 # Path to the assignment template repositories. Again, none of
 # the parent directories should be a git repo. Assumed to be relative to

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -19,7 +19,7 @@ def path_to_example(dataset):
     ----------
     dataset: string
         Name of a dataset to access (e.g., "config.yml")
-            
+
     Returns
     -------
     string
@@ -58,8 +58,8 @@ def create_dir_struct(course_name="course_dir", f=False):
     if os.path.isdir(main_dir):
         raise ValueError(
             """
-            Ooops! It looks like the directory {} already exists on your computer. You might have already 
-            run quickstart in this directory. Consider using another course name or deleting the existing directory 
+            Ooops! It looks like the directory {} already exists on your computer. You might have already
+            run quickstart in this directory. Consider using another course name or deleting the existing directory
             if you do not need it.""".format(
                 course_name
             )
@@ -80,9 +80,6 @@ def create_dir_struct(course_name="course_dir", f=False):
                 "/Users/karen/awesome-course", main_dir
             )
             filedata = filedata.replace(
-                "earth-analytics-bootcamp", course_name
-            )
-            filedata = filedata.replace(
                 "/Users/me/awesome-course/cloned_dirs",
                 os.path.join(main_dir, "student-cloned-repos"),
             )
@@ -94,8 +91,8 @@ def create_dir_struct(course_name="course_dir", f=False):
             file.write(filedata)
     print(
         """
-        Directory structure created to begin using abc-classroom at {}. 
-        All directories needed and a configuration file to modify have been created. To proceed, please 
+        Directory structure created to begin using abc-classroom at {}.
+        All directories needed and a configuration file to modify have been created. To proceed, please
         move your sample roster and nbgrader directory into {} created by quickstart.""".format(
             main_dir, course_name
         )

--- a/abcclassroom/template.py
+++ b/abcclassroom/template.py
@@ -32,7 +32,7 @@ def new_update_template(args):
     github.init_and_commit(template_repo_path, args.custom_message)
 
     # create / append assignment entry in config
-    course_dir = cf.get_config_option(config, "course_dir", True)
+    course_dir = cf.get_config_option(config, "course_directory", True)
     cf.set_config_option(
         config,
         "assignments",

--- a/abcclassroom/template.py
+++ b/abcclassroom/template.py
@@ -16,6 +16,8 @@ from . import utils
 def new_update_template(args):
     """
     Creates or updates an assignment template repository. Implementation of both the new_template and update_template console scripts (which perform the same basic functions but with different command line arguments and defaults).
+
+    Creates an assignment entry in the config file if one does not already exist.
     """
     print("Loading configuration from config.yml")
     config = cf.get_config()
@@ -28,6 +30,16 @@ def new_update_template(args):
     copy_assignment_files(config, template_repo_path, assignment)
     create_extra_files(config, template_repo_path, assignment)
     github.init_and_commit(template_repo_path, args.custom_message)
+
+    # create / append assignment entry in config
+    course_dir = cf.get_config_option(config, "course_dir", True)
+    cf.set_config_option(
+        config,
+        "assignments",
+        assignment,
+        append_value=True,
+        configpath=course_dir,
+    )
 
     # optional github steps
     if args.github:
@@ -84,18 +96,7 @@ def create_template_dir(config, assignment, mode="fail"):
         )
         os.mkdir(parent_path)
 
-    # Set up the name of the template repo and create the dir
-    # if there is a shortname defined, use that in path
-    course_name = cf.get_config_option(config, "short_coursename")
-    if course_name is None:
-        course_name = cf.get_config_option(config, "course_name")
-    if course_name is None:
-        print(
-            "Error: One of course_name or short_coursename must be set in config.yml"
-        )
-        sys.exit(1)
-
-    repo_name = course_name + "-" + assignment + "-template"
+    repo_name = assignment + "-template"
     template_path = Path(parent_path, repo_name)
     dir_exists = template_path.is_dir()
     if not dir_exists:
@@ -177,9 +178,8 @@ def create_extra_files(config, template_repo, assignment):
         if len(contents) > 0:
             if file == "README.md":
                 firstline = ""
-                coursename = cf.get_config_option(config, "course_name", False)
-                if assignment and coursename:
-                    first_line = "# {}: {}".format(coursename, assignment)
+                if assignment:
+                    first_line = "# {}".format(assignment)
                 else:
                     first_line = "# README"
                 contents.insert(0, first_line)

--- a/abcclassroom/tests/conftest.py
+++ b/abcclassroom/tests/conftest.py
@@ -9,8 +9,6 @@ def default_config():
     """
     config = {
         "template_dir": "test_template",
-        "short_coursename": "tc",
-        "course_name": "Test_course",
         "nbgrader_dir": "nbgrader",
         "extra_files": {
             "testfile.txt": ["line1", "line2"],

--- a/abcclassroom/tests/test_assignment_template.py
+++ b/abcclassroom/tests/test_assignment_template.py
@@ -3,9 +3,19 @@
 import pytest
 import os
 from pathlib import Path
+from ruamel.yaml import YAML
 
 import abcclassroom.template as abctemplate
 import abcclassroom.github as github
+import abcclassroom.config as cf
+
+
+@pytest.fixture
+def config_file(default_config, tmp_path):
+    """
+    Writes the config to a file in tmp_path
+    """
+    cf.write_config(default_config, tmp_path)
 
 
 def test_create_template_dir(default_config, tmp_path):
@@ -13,14 +23,13 @@ def test_create_template_dir(default_config, tmp_path):
     Tests that create_template_dir with default mode "fail" creates a directory with the expected name.
     """
     default_config["course_directory"] = tmp_path
-    shortname = default_config["short_coursename"]
     templates_dir = default_config["template_dir"]
     assignment = "test_assignment"
     template_path = abctemplate.create_template_dir(default_config, assignment)
     assert os.path.isdir(template_path)
 
     assert template_path == Path(
-        tmp_path, templates_dir, "{}-{}-template".format(shortname, assignment)
+        tmp_path, templates_dir, "{}-template".format(assignment)
     )
 
 
@@ -86,18 +95,6 @@ def test_move_git_dir(default_config, tmp_path):
     assert Path(template_path, ".git").exists()
 
 
-def test_coursename_config_options(tmp_path):
-    # test that it fails if neither short_coursename or course_name is set
-    localconfig = {
-        "template_dir": "test_template",
-        "course_directory": tmp_path,
-    }
-    with pytest.raises(SystemExit):
-        template_path = abctemplate.create_template_dir(
-            localconfig, "test_assignment"
-        )
-
-
 # Tests for copy_assignment_files method
 def test_copy_assignment_files(default_config, tmp_path):
     # test that contents are the same for target and source directory
@@ -143,21 +140,9 @@ def test_create_extra_files(default_config, tmp_path):
 def test_create_extra_files_readme(default_config, tmp_path):
     # tests for the special README.md case
     default_config["course_directory"] = tmp_path
-    course_name = default_config["course_name"]
     assignment = "assignment1"
     template_repo = abctemplate.create_template_dir(default_config, assignment)
     abctemplate.create_extra_files(default_config, template_repo, assignment)
     assert Path(template_repo, "README.md").exists()
     f = open(Path(template_repo, "README.md"))
-    assert f.readline() == "# {}: {}\n".format(course_name, assignment)
-
-    # test when course_name not set
-    del default_config["course_name"]
-    abctemplate.create_extra_files(default_config, template_repo, assignment)
-    assert Path(template_repo, "README.md").exists()
-
-    f = open(Path(template_repo, "README.md"))
-    assert f.readline() == "# README\n"
-
-
-# def test_do_local_git_things(template_dir, custom_message):
+    assert f.readline() == "# {}\n".format(assignment)

--- a/abcclassroom/tests/test_config.py
+++ b/abcclassroom/tests/test_config.py
@@ -1,0 +1,100 @@
+# Tests for config methods
+
+import pytest
+import os
+from ruamel.yaml import YAML
+from pathlib import Path
+
+import abcclassroom.config as abcconfig
+
+# def __write_config_file(config,tmp_path):
+#     yaml = YAML()
+#     cfpath = Path(tmp_path,"config.yml")
+#     with open(cfpath, "w") as f:
+#         yaml.dump(config, f)
+
+
+def test_write_config(default_config, tmp_path):
+    abcconfig.write_config(default_config, configpath=tmp_path)
+    assert Path(tmp_path, "config.yml").exists()
+
+
+def test_get_config(default_config, tmp_path):
+    abcconfig.write_config(default_config, configpath=tmp_path)
+    config = abcconfig.get_config(configpath=tmp_path)
+    assert config == default_config
+
+
+def test_get_config_option(default_config):
+    # test that works in basic get existing option cases
+    assert (
+        abcconfig.get_config_option(default_config, "template_dir")
+        == "test_template"
+    )
+    assert (
+        abcconfig.get_config_option(default_config, "template_dir", True)
+        == "test_template"
+    )
+    assert (
+        abcconfig.get_config_option(default_config, "template_dir", False)
+        == "test_template"
+    )
+
+    # test we're ok when option not required and missing
+    assert (
+        abcconfig.get_config_option(default_config, "floofykitten", False)
+        == None
+    )
+
+    # test that fails when required but absent
+    with pytest.raises(SystemExit):
+        abcconfig.get_config_option(default_config, "floofykitten", True)
+
+
+def test_set_config_option(default_config, tmp_path):
+    abcconfig.write_config(default_config, configpath=tmp_path)
+    # test writing new value
+    config = abcconfig.set_config_option(
+        default_config, "pie", "apple", configpath=tmp_path
+    )
+    assert abcconfig.get_config_option(config, "pie") == "apple"
+
+    # test replacing existing value
+    config = abcconfig.set_config_option(
+        default_config, "template_dir", "templates", configpath=tmp_path
+    )
+    assert abcconfig.get_config_option(config, "template_dir") == "templates"
+    config = abcconfig.get_config(configpath=tmp_path)
+    assert abcconfig.get_config_option(config, "template_dir") == "templates"
+
+    # test adding values to existing single value
+    config = abcconfig.set_config_option(
+        default_config,
+        "pie",
+        "pumpkin",
+        append_value=True,
+        configpath=tmp_path,
+    )
+    assert abcconfig.get_config_option(config, "pie") == ["apple", "pumpkin"]
+    print(config)
+    # test adding values to existing list
+    config = abcconfig.set_config_option(
+        default_config, "pie", "peach", append_value=True, configpath=tmp_path
+    )
+    print(config)
+    assert abcconfig.get_config_option(config, "pie") == [
+        "apple",
+        "pumpkin",
+        "peach",
+    ]
+
+    # test replacing existing list
+    pie_list = ["pecan", "sugar"]
+    config = abcconfig.set_config_option(
+        default_config,
+        "pie",
+        pie_list,
+        append_value=False,
+        configpath=tmp_path,
+    )
+    assert abcconfig.get_config_option(config, "pie") == ["pecan", "sugar"]

--- a/docs/new_assignment.rst
+++ b/docs/new_assignment.rst
@@ -1,43 +1,28 @@
 Create A New Assignment Git Repo
 --------------------------------
 
-If you are working in GitHub classroom, you will need to:
+Creating a new assignment involves:
 
-1. Create a template repository for each student assignment. This is the repo that each student will get a copy of when you release the assignment for them to work on.
-2. Push that template repository to your GitHub organization that is setup with a classroom, for distribution.
+1. Creating a template repository for each student assignment. This is the repo containing assignment files that each student will get a copy of when you release the assignment for them to work on.
+2. Pushing that template repository to your GitHub organization that is setup with a classroom, for distribution.
 
 If you are using nbgrader, then the files needed to distribute and grade each assignment
 live in a sub directory of **nbgrader** called **releases**.
 
-The ``abc-assignment-template`` command will pull files from the releases directory
-and create a new assignment template directory that is also initialized as a git
-repository.
-
-Creating a new assignment template involves getting your local assignment
-files into
-a new repository on GitHub that you can use as a template for a GitHub
-classroom assignment.
+The ``abc-new-template`` and ``abc-update-template`` commands allow you to create and update template repositories.
 
 .. note::
-   If you are using nbgrader you will want to 1. run ``$ nbgrader quickstart nbgrader``
-   to setup the nbgrader directory structure within your new course created with
-   ``abc-classroom quickstart course-name-here``. Note that we suggest that you name
-   your nbgrader course ``nbgrader-coursename`` to make the directory structure
-   a bit cleaner. Once that is setup: 2. Create an nbgrader assignment using
-   ``nbgrader generate_assignment assignment1``. This step will move the
-   assignments created in the source/ nbgrader directory over to a ``release/``
-   directory. abc-classroom will look for that release/ directory to find
-   assignment files each time you run ``abc-assignment-template``. Once you have
-   created and released the assignment with nbgrader, you can then
-   create the assignment template using abc-classroom which will generate a new
-   template GitHub repo that you can use with GitHub classroom.
+   The current version abc-classroom assumes that you are using nbgrader and therefore have the student version of assignment files in the ``nbgrader_dir/release/assignment_name`` directory (where ``nbgrader_dir`` is defined in the abc-classroom ``config.yml``). See :doc:`get-started` for more details about abc-classroom and nbgrader setup.
 
-How To Create A New Assignment Template repository
-==================================================
+How To Create and Update Template Repositories
+==============================================
 
-Creating a new assignment using ``abc-assignment-template`` requires you to first
-update your config.yml file. Be sure to read the documentation about updating the config
-before following the steps below <TODO: add link to that documentation>.
+There are two template scripts : `abc-new-template` and `abc-update-template`. The 'new' script is for first-time creation of a new assignment template repository from a directory of assignment files. The 'update' script allows you to quickly update the local and remote repositories after making changes to assignment files.
+
+Make sure you have updated your ``config.yml`` before running the template scripts. See the Configuration section below for details.
+
+Creating a New Template repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To create a new assignment git repo:
 
@@ -45,29 +30,29 @@ To create a new assignment git repo:
 
 2. To create a new assignment template called **assignment1** run:
 
-  ``$ abc-assignment-template assignment1``
+  ``$ abc-new-template assignment1``
 
-``abc-assignment-template`` will then perform the following steps:
+``abc-new-template`` will then perform the following steps:
 
-* create a local directory in the xxx/cloned_repos?? called assignment1 and initialize as a git repository
-* copy files from the ``nbgrader/release/assignment`` directory
-* create any additional files as listed in ``config.yml``
-* create a new repository on GitHub with the name ``assignment1-template``
-* add and commit the local files, and push the contents to GitHub
+* get the name of the `template_dir` directory from the config file
+* create a local directory in ``template_dir`` called ``assignment1-template`` and initialize as a git repository
+* copy files from the ``nbgrader/release/assignment1`` directory
+* create any extra files as listed in ``config.yml``
+* git add and git commit the local files
+* (optionally, if using ``--github`` flag) create a new repository on GitHub with the name ``assignment1-template`` and push the contents of the local repo to GitHub
 
-Command line arguments
-======================
+**Command line options**
 
-Run `abc-assignment_template -h` to see the command line arguments. The output
-is reproduced here::
+Run ``abc-new-template -h`` to see the options. The output is reproduced below::
 
-    usage: abc-assignment-template [-h] [--custom-message] [--local-only]
-                                   [--mode {delete,fail,merge}]
-                                   assignment
+    usage: abc-new-template [-h] [--custom-message] [--github]
+                            [--mode {delete,fail,merge}]
+                            assignment
 
     Create a new assignment template repository: creates local directory, copy /
-    create required files, intialize as git repo, create remote repo on GitHub,
-    and push local repo to GitHub. Will open git editor to ask for commit message.
+    create required files, intialize as git repo, and (optionally) create remote
+    repo on GitHub and push local repo to GitHub. Will open git editor to ask for
+    commit message if custom message requested.
 
     positional arguments:
       assignment            Name of assignment. Must match name in nbgrader
@@ -76,16 +61,54 @@ is reproduced here::
     optional arguments:
       -h, --help            show this help message and exit
       --custom-message      Use a custom commit message for git. Will open the
-                            default git text editor for entry. If not set, will
-                            use message 'Initial commit'.
-      --local-only          Create local template repository only; do not create
-                            GitHub repo or push to GitHub (default: False)
+                            default git text editor for entry (if not set, uses
+                            default message 'Initial commit').
+      --github              Also perform the GitHub operations (create remote repo
+                            on GitHub and push to remote (by default, only does
+                            local repository setup).
       --mode {delete,fail,merge}
                             Action if template directory already exists. Choices
-                            are: delete = delete the directory and contents; fail
-                            = exit and let user delete or rename; merge = keep
-                            existing dir, overwrite existing files, add new files.
-                            Default is fail.
+                            are: delete = delete contents before proceeding
+                            (except .git directory); merge = keep existing dir,
+                            overwrite existing files, add new files (Default =
+                            fail).
+
+Updating an existing template repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update an existing template repository (for example, if you change assignment files and want to push new versions to GitHub), use the ``abc-update-template`` scripts. Assuming that ``template_dir/assignment1-template`` exists:
+
+```abc-update-template assignment1``
+
+will:
+
+* copy any files in ``nbgrader/release/assignment1`` to ``template_dir/assignment1-template`` (overwriting any existing files with the same name; use the ``-delete`` mode if you want to erase the existing template before starting)
+* git add and git commit the changes
+* push the changes to GitHub
+
+**Command line arguments**
+
+Run `abc-update_template -h` to see the command line arguments. The output
+is reproduced here::
+
+    usage: abc-update-template [-h] [--mode {delete,merge}] assignment
+
+    Updates an existing assignment template repository: update / add new and
+    changed files, then push local changes to GitHub. Will open git editor to ask
+    for commit message.
+
+    positional arguments:
+      assignment            Name of assignment. Must match name in nbgrader
+                            release directory
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --mode {delete,merge}
+                            What to do with existing contents of template
+                            directory. Choices are: delete = remove contents
+                            before proceeding (leaving .git directory); merge =
+                            overwrite existing files add new files (Default =
+                            merge).
 
 
 Configuration settings
@@ -95,7 +118,5 @@ Creating an assignment uses these settings from ``config.yml``:
 
 * ``template_dir`` : the directory where the local git repository will be created.
 * ``organization`` : the GitHub organization where the new remote repository will be created
-* ``course_name`` : (optional) If set, the name of the local git repository and remote GitHub repository will be ``course_name-assignment-template``. If ``short_coursename`` is not set, you must set course_name.
-* ``short_coursename`` : (optional) If set, the the name of the local git repository and remote GitHub repository will be ``short_coursename-assignment-template``.
 * ``nbgrader_dir`` : the path to the local nbgrader directory.
 * ``extra_files`` : (optional) Any extra files that you want to add to the repo, such as .gitignore or README


### PR DESCRIPTION
Addresses #137 and #138. 

* abc-classroom will no longer modify the assignment name provided by adding the coursename as a prefix. 
* Name of each assignment gets added to an `assignments` section of the config. 
* Removed coursename and short_coursename from config because these are no longer used. 
* Added tests for assignment template scripts, as well as config functions
* Made some progress at more explicit handling of paths (a.k.a. where is my config file?)

