### PR TITLE
Use generic course_materials instead of nbgrader

### DIFF
--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -420,8 +420,9 @@ def author():
 
 def clone():
     """
-    Clone the student repositories for the assignment and (optionall) copies notebook files into the nbgrader 'submitted' directory. Clones into the clone_dir
-    directory, as specified in config.yml.
+    Clone the student repositories for the assignment and (optionall) copies
+    notebook files into the course_materials 'submitted' directory. Clones into
+    the clone_dir directory, as specified in config.yml.
 
     Requires that you have filename of student roster
     defined in config.yml and that the roster file exists.
@@ -433,7 +434,7 @@ def clone():
     parser = argparse.ArgumentParser(description=clone.__doc__)
     parser.add_argument(
         "assignment",
-        help="Name of assignment. Must match name in nbgrader release directory",
+        help="Name of assignment. Must match assignment name in course_materials directories",
     )
     parser.add_argument(
         "--skip-existing",
@@ -455,7 +456,7 @@ def new_template():
     parser = argparse.ArgumentParser(description=new_template.__doc__)
     parser.add_argument(
         "assignment",
-        help="Name of assignment. Must match name in nbgrader release directory",
+        help="Name of assignment. Must match name in course_materials/release directory",
     )
     parser.add_argument(
         "--custom-message",
@@ -486,7 +487,7 @@ def update_template():
     parser = argparse.ArgumentParser(description=update_template.__doc__)
     parser.add_argument(
         "assignment",
-        help="Name of assignment. Must match name in nbgrader release directory",
+        help="Name of assignment. Must match name in course_materials/release directory",
     )
     parser.add_argument(
         "--mode",

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -87,7 +87,6 @@ def clone_student_repos(args):
 
 def copy_assignment_files(config, student, assignment):
     """Copies all notebook files from clone_dir to course_materials/submitted. Will overwrite any existing files with the same name."""
-    print("Am I getting any output?")
     course_dir = cf.get_config_option(config, "course_directory", True)
     materials_dir = cf.get_config_option(config, "course_materials", False)
     clone_dir = cf.get_config_option(config, "clone_dir", True)

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -37,7 +37,9 @@ def clone_or_update_repo(organization, repo, clone_dir, skip_existing):
 
 def clone_student_repos(args):
     """Iterates through the student roster, clones each repo for this
-    assignment into the directory specified in the config, and then copies the notebook files into the nbgrader 'submitted' directory, if nbgrader_dir set in config.yml."""
+    assignment into the directory specified in the config, and then copies the
+    notebook files into the 'course_materials/submitted' directory, based on
+    course_materials set in config.yml."""
 
     assignment = args.assignment
     skip_existing = args.skip_existing
@@ -48,11 +50,11 @@ def clone_student_repos(args):
     course_dir = cf.get_config_option(config, "course_directory", True)
     clone_dir = cf.get_config_option(config, "clone_dir", True)
     organization = cf.get_config_option(config, "organization", True)
-    nbgrader_dir = cf.get_config_option(config, "nbgrader_dir", False)
+    materials_dir = cf.get_config_option(config, "course_materials", False)
 
-    if nbgrader_dir is None:
+    if materials_dir is None:
         print(
-            "No nbgrader_dir set in config.yml. Will clone repositories but will not copy any assignment files."
+            "No course_materials directory set in config.yml. Will clone repositories but will not copy any assignment files."
         )
     try:
         Path(course_dir, clone_dir).mkdir(exist_ok=True)
@@ -67,7 +69,7 @@ def clone_student_repos(args):
                     clone_or_update_repo(
                         organization, repo, clone_dir, skip_existing
                     )
-                    if nbgrader_dir is not None:
+                    if materials_dir is not None:
                         copy_assignment_files(config, student, assignment)
                 except RuntimeError as err:
                     missing.append(repo)
@@ -84,15 +86,15 @@ def clone_student_repos(args):
 
 
 def copy_assignment_files(config, student, assignment):
-    """Copies all notebook files from clone_dir to nbgrader_dir/submitted. Will overwrite any existing files with the same name."""
+    """Copies all notebook files from clone_dir to course_materials/submitted. Will overwrite any existing files with the same name."""
     print("Am I getting any output?")
     course_dir = cf.get_config_option(config, "course_directory", True)
-    nbgrader_dir = cf.get_config_option(config, "nbgrader_dir", False)
+    materials_dir = cf.get_config_option(config, "course_materials", False)
     clone_dir = cf.get_config_option(config, "clone_dir", True)
     repo = "{}-{}".format(assignment, student)
     files = Path(course_dir, clone_dir, repo).glob("*.ipynb")
     destination = Path(
-        course_dir, nbgrader_dir, "submitted", student, assignment
+        course_dir, materials_dir, "submitted", student, assignment
     )
     destination.mkdir(parents=True, exist_ok=True)
     print(

--- a/abcclassroom/example-data/config.yml
+++ b/abcclassroom/example-data/config.yml
@@ -7,27 +7,28 @@ organization: earth-analytics-edu
 # set up for you
 course_directory: /Users/karen/awesome-course
 
-
 # Path to the course roster (list of students downloaded from
 # github classroom). If the roster is in the course_directory, simply enter
 # the filename (otherwise, enter the path relative to the course_directory).
 roster: roster.csv
 
-# Path to the nbgrader directory. Assumed to be relative to course_dir unless
-# you enter an absolute path (i.e. starting with '/' on Linux or OS X or with
-# 'C:' on Windows).
-nbgrader_dir: nbgrader
+# Path to the directory that holds your course materials. If you are using
+# nbgrader, this is the top-level nbgrader directory. Path assumed to be
+# relative to course_dir unless you enter an absolute path (i.e. starting
+# with '/' on Linux or OS X or with 'C:' on Windows).
+course_materials: nbgrader
 
 # Path to the directory where you want to clone the student repositories.
-# Assumed to be relative to course_dir unless you enter an absolute path (i.e. starting with '/' on Linux or OS X or with 'C:' on Windows). None of the
-# parent directories should be git repositories.
-clone_dir: /Users/me/awesome-course/cloned_dirs
+# Assumed to be relative to course_dir unless you enter an absolute path
+# (i.e. starting with '/' on Linux or OS X or with 'C:' on Windows). None of
+# the parent directories of clone_dir should be git repositories.
+clone_dir: cloned_dirs
 
 # Path to the assignment template repositories. Again, none of
 # the parent directories should be a git repo. Assumed to be relative to
 # course_dir unless you enter an absolute path (i.e. starting with '/' on
 # Linux or OS X or with 'C:' on Windows).
-template_dir: /Users/me/awesome-course/assignment_repos
+template_dir: assignment_repos
 
 # Additional files that will be created and added to the student repositories
 # Each item in the list will be added as a line in the file

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -1,0 +1,62 @@
+"""
+abc-classroom.feedback
+======================
+
+"""
+
+from pathlib import Path
+import csv
+
+from . import config as cf
+from . import github
+
+
+def feedback(args):
+    """
+    Copies feedback reports to local student repositories, commits the changes, and (optionally) pushes to github. Assumes files are in the directory course_materials/feedback/student/assignment. Copies all files in the source directory.
+    """
+    assignment = args.assignment
+    do_github = args.github
+
+    print("Loading configuration from config.yml")
+    config = cf.get_config()
+
+    # get various paths from config
+    roster_filename = cf.get_config_option(config, "roster", True)
+    course_dir = cf.get_config_option(config, "course_directory", True)
+    clone_dir = cf.get_config_option(config, "clone_dir", True)
+    organization = cf.get_config_option(config, "organization", True)
+    materials_dir = cf.get_config_option(config, "course_materials", True)
+
+    try:
+        feedback_dir = Path(course_dir, materials_dir, "feedback")
+        with open(roster_filename, newline="") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                student = row["github_username"]
+                source_files = Path(feedback_dir, student, assignment).glob(
+                    "*"
+                )
+                if len(source_files) == 0:
+                    print(
+                        "No feedback files found for student {}".format(
+                            student
+                        )
+                    )
+                    continue
+                # if there are files, copy them and do git / github stuff
+                repo = "{}-{}".format(assignment, student)
+                destination_dir = Path(clone_dir, repo)
+                for f in files:
+                    print("copying {} to {}".format(f, destination))
+                    copy(f, destination)
+                github.commit_all_changes(
+                    destination_dir,
+                    msg="Adding feedback for assignment {}".format(assignment),
+                )
+                if do_github:
+                    github.push_to_github(destination_dir)
+
+    except FileNotFoundError as err:
+        print("Cannot find roster file".format(roster_filename))
+        print(err)

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -93,7 +93,7 @@ def create_dir_struct(course_name="course_dir", f=False):
         """
         Directory structure created to begin using abc-classroom at {}.
         All directories needed and a configuration file to modify have been created. To proceed, please
-        move your sample roster and nbgrader directory into {} created by quickstart.""".format(
+        move your sample roster and course_materials directory into {} created by quickstart.""".format(
             main_dir, course_name
         )
     )

--- a/abcclassroom/template.py
+++ b/abcclassroom/template.py
@@ -140,13 +140,13 @@ def create_template_dir(config, assignment, mode="fail"):
 
 
 def copy_assignment_files(config, template_repo, assignment):
-    """Copy all of the files from the nbgrader release directory for the
+    """Copy all of the files from the course_materials/release directory for the
     assignment into the template repo directory.
     """
 
     print("Getting assignment files")
     course_dir = cf.get_config_option(config, "course_directory", True)
-    nbgrader_dir = cf.get_config_option(config, "nbgrader_dir", True)
+    nbgrader_dir = cf.get_config_option(config, "course_material", True)
     parent_path = utils.get_abspath(nbgrader_dir, course_dir)
     release_dir = os.path.join(parent_path, "release", assignment)
     if not os.path.exists(release_dir):

--- a/abcclassroom/template.py
+++ b/abcclassroom/template.py
@@ -146,12 +146,12 @@ def copy_assignment_files(config, template_repo, assignment):
 
     print("Getting assignment files")
     course_dir = cf.get_config_option(config, "course_directory", True)
-    nbgrader_dir = cf.get_config_option(config, "course_material", True)
-    parent_path = utils.get_abspath(nbgrader_dir, course_dir)
+    materials_dir = cf.get_config_option(config, "course_materials", True)
+    parent_path = utils.get_abspath(materials_dir, course_dir)
     release_dir = os.path.join(parent_path, "release", assignment)
     if not os.path.exists(release_dir):
         print(
-            "nbgrader release directory {} does not exist; exiting\n".format(
+            "release directory {} does not exist; exiting\n".format(
                 release_dir
             )
         )

--- a/abcclassroom/tests/conftest.py
+++ b/abcclassroom/tests/conftest.py
@@ -9,7 +9,7 @@ def default_config():
     """
     config = {
         "template_dir": "test_template",
-        "materials_dir": "nbgrader",
+        "course_materials": "nbgrader",
         "clone_dir": "student-cloned-repos",
         "extra_files": {
             "testfile.txt": ["line1", "line2"],

--- a/abcclassroom/tests/conftest.py
+++ b/abcclassroom/tests/conftest.py
@@ -9,7 +9,7 @@ def default_config():
     """
     config = {
         "template_dir": "test_template",
-        "nbgrader_dir": "nbgrader",
+        "materials_dir": "nbgrader",
         "clone_dir": "student-cloned-repos",
         "extra_files": {
             "testfile.txt": ["line1", "line2"],

--- a/abcclassroom/tests/test_assignment_template.py
+++ b/abcclassroom/tests/test_assignment_template.py
@@ -100,9 +100,9 @@ def test_copy_assignment_files(default_config, tmp_path):
     # test that contents are the same for target and source directory
     default_config["course_directory"] = tmp_path
     assignment = "assignment1"
-    # first, set up the test nbgrader directory
+    # first, set up the test course materials directory
     nbpath = Path(
-        tmp_path, default_config["nbgrader_dir"], "release", assignment
+        tmp_path, default_config["course_materialsr"], "release", assignment
     )
     nbpath.mkdir(parents=True)
     # create some temporary files
@@ -116,7 +116,7 @@ def test_copy_assignment_files(default_config, tmp_path):
 
 
 def test_copy_assignment_files_fails_nodir(default_config, tmp_path):
-    # test that fails if nbgrader dir does not exist
+    # test that fails if course_materials dir does not exist
     default_config["course_directory"] = tmp_path
     assignment = "assignment1"
     template_repo = abctemplate.create_template_dir(default_config, assignment)

--- a/abcclassroom/tests/test_assignment_template.py
+++ b/abcclassroom/tests/test_assignment_template.py
@@ -102,7 +102,7 @@ def test_copy_assignment_files(default_config, tmp_path):
     assignment = "assignment1"
     # first, set up the test course materials directory
     nbpath = Path(
-        tmp_path, default_config["course_materialsr"], "release", assignment
+        tmp_path, default_config["course_materials"], "release", assignment
     )
     nbpath.mkdir(parents=True)
     # create some temporary files

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -43,8 +43,8 @@ def test_files(default_config, tmp_path):
 
 
 def test_copy_assignment_files(default_config, test_files):
-    nbgrader_dir = Path(
-        default_config["course_directory"], default_config["nbgrader_dir"]
+    materials_dir = Path(
+        default_config["course_directory"], default_config["course_materials"]
     )
     assignment = test_data["assignment"]
     students = test_data["students"]
@@ -52,9 +52,11 @@ def test_copy_assignment_files(default_config, test_files):
         abcclone.copy_assignment_files(default_config, s, assignment)
 
         assert Path(
-            nbgrader_dir, "submitted", s, assignment, "nb1.ipynb"
+            materials_dir, "submitted", s, assignment, "nb1.ipynb"
         ).exists()
         assert (
-            Path(nbgrader_dir, "submitted", s, assignment, "junk.csv").exists()
+            Path(
+                materials_dir, "submitted", s, assignment, "junk.csv"
+            ).exists()
             == False
         )

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -105,13 +105,13 @@ Flags
  delete anything currently in your course directory, but will allow you to start over fresh.
 
  ## Optional but Required for Now
- ``abc-classroom`` does not fully depend upon ``nbgrader`` but does require a ``nbgrader``
- directory structure in it's early stages of development. We suggest that you
- setup an ``nbgrader`` directory within the quickstart directory that you created
- above using abc-classroom by:
+ ``abc-classroom`` does not fully depend upon ``nbgrader`` but does require a
+ course_materials directory that follows the nbgrader directory structure. We
+ suggest that you setup an course_materials directory within the quickstart
+ directory that you created above by:
 
  1. Installing ``nbgrader`` and then running
- 2. ``$ nbgrader quickstart nbgrader``: this will create a nbgrader course directory called **nbgrader**.
+ 2. ``$ nbgrader quickstart course_materials``: this will create a nbgrader course directory called **course_materials**.
 
 Your final directory will look something like this:
 
@@ -120,7 +120,7 @@ Your final directory will look something like this:
   course-name-here/
     cloned-files/
     template-files/
-    nbgrader/
+    course_materials/
       release/
     config.yml
 
@@ -128,12 +128,13 @@ Config.yml check
 ~~~~~~~~~~~~~~~~~
 
 You can tell ``abc-classroom`` where your assignment directory is located using the
-``config.yml`` file. The ``nbgrader_dir`` parameter in that file can be changed to
-any location on your computer that contains your assignments.
+``config.yml`` file. Change the ``course_materials`` parameter in that file to
+the location on your computer that contains your assignments (if you used the
+nbgrader quickstart, above, then use the directory created by nbgrader).
 
 .. code-block:: yaml
 
-  # Path to the nbgrader directory. Assumed to be relative to course_dir unless
+  # Path to the course_materials directory. Assumed to be relative to course_dir unless
   # you enter an absolute path (i.e. starting with '/' on Linux or OS X or with
   # 'C:' on Windows).
-  nbgrader_dir: nbgrader
+  course_materials: course_materials

--- a/docs/new_assignment.rst
+++ b/docs/new_assignment.rst
@@ -13,7 +13,7 @@ This repo should have all of the files that a student will need to complete the 
 The ``abc-new-template`` and ``abc-update-template`` commands allow you to create and update template repositories.
 
 .. note::
-   The current version abc-classroom assumes that you are using nbgrader and therefore have the student version of assignment files in the ``nbgrader_dir/release/assignment_name`` directory (where ``nbgrader_dir`` is defined in the abc-classroom ``config.yml``). See :doc:`get-started` for more details about abc-classroom and nbgrader setup.
+   The current version abc-classroom assumes that you have the student version of assignment files in the ``course_materials/release/assignment_name`` directory (where ``course_materials`` is defined in the abc-classroom ``config.yml``). This mirrors the structure of an nbgrader course. See :doc:`get-started` for more details about abc-classroom and nbgrader setup.
 
 How To Create and Update Template Repositories
 ==============================================
@@ -37,7 +37,7 @@ To create a GitHub classroom homework assignment template repo:
 
 * get the name of the `template_dir` directory from the config file
 * create a local directory in ``template_dir`` called ``assignment1-template`` and initialize as a git repository
-* copy files from the ``nbgrader/release/assignment1`` directory
+* copy files from the ``course_materials/release/assignment1`` directory
 * create any extra files as listed in ``config.yml``
 * git add and git commit the local files
 * (optionally, if using ``--github`` flag) create a new repository on GitHub with the name ``assignment1-template`` and push the contents of the local repo to GitHub
@@ -56,7 +56,7 @@ Run ``abc-new-template -h`` to see the options. The output is reproduced below::
     commit message if custom message requested.
 
     positional arguments:
-      assignment            Name of assignment. Must match name in nbgrader
+      assignment            Name of assignment. Must match name in course_materials
                             release directory
 
     optional arguments:
@@ -83,7 +83,7 @@ To update an existing template repository (for example, if you change assignment
 
 will:
 
-* copy any files in ``nbgrader/release/assignment1`` to ``template_dir/assignment1-template`` (overwriting any existing files with the same name; use the ``-delete`` mode if you want to erase the existing template before starting)
+* copy any files in ``course_materials/release/assignment1`` to ``template_dir/assignment1-template`` (overwriting any existing files with the same name; use the ``-delete`` mode if you want to erase the existing template before starting)
 * git add and git commit the changes
 * push the changes to GitHub
 
@@ -99,7 +99,7 @@ is reproduced here::
     for commit message.
 
     positional arguments:
-      assignment            Name of assignment. Must match name in nbgrader
+      assignment            Name of assignment. Must match name in course_materials
                             release directory
 
     optional arguments:
@@ -119,5 +119,5 @@ Creating an assignment uses these settings from ``config.yml``:
 
 * ``template_dir`` : the directory where the local git repository will be created.
 * ``organization`` : the GitHub organization where the new remote repository will be created
-* ``nbgrader_dir`` : the path to the local nbgrader directory.
+* ``materials_dir`` : the path to the local directory where you are storing course materials (the top-level nbgrader dir if you are using nbgrader).
 * ``extra_files`` : (optional) Any extra files that you want to add to the repo, such as .gitignore or README


### PR DESCRIPTION
Addresses #133 

We still assume / create most of the nbgrader directory structure under the course_materials directory, but no longer call this 'nbgrader' in the config, the code, or the docs. 

PR #147 should be merged first. 