### PR TITLE
Update quickstart tests for new config options

### DIFF
--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -33,7 +33,7 @@ def path_to_example(dataset):
     return os.path.join(data_dir, dataset)
 
 
-def create_dir_struct(course_name="course_dir", f=False):
+def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
     """
     Create a directory structure that can be used to start an abc-classroom course. This includes a main directory,
     two sub directories for templates and cloned files, and a start to a configuration file.
@@ -51,7 +51,9 @@ def create_dir_struct(course_name="course_dir", f=False):
                 course_name
             )
         )
-    main_dir = os.path.join(os.getcwd(), course_name)
+    if working_dir is None:
+        working_dir = os.getcwd()
+    main_dir = os.path.join(working_dir, course_name)
     if f and os.path.isdir(main_dir):
         rmtree(main_dir)
     # Make sure that the main_dir doesn't exist already
@@ -67,27 +69,27 @@ def create_dir_struct(course_name="course_dir", f=False):
     # Making all the needed directories and subdirectories, and creating the configuration file.
     dir_names = [
         main_dir,
-        os.path.join(main_dir, "student-cloned-repos"),
-        os.path.join(main_dir, "assignment-template-repos"),
+        os.path.join(main_dir, "clone_dir"),
+        os.path.join(main_dir, "template_dir"),
     ]
     for directories in dir_names:
         os.mkdir(directories)
     copy(config, main_dir)
     if course_name:
-        with open(os.path.join(course_name, "config.yml"), "r") as file:
+        with open(os.path.join(main_dir, "config.yml"), "r") as file:
             filedata = file.read()
             filedata = filedata.replace(
                 "/Users/karen/awesome-course", main_dir
             )
             filedata = filedata.replace(
                 "/Users/me/awesome-course/cloned_dirs",
-                os.path.join(main_dir, "student-cloned-repos"),
+                os.path.join(main_dir, "clone_dir"),
             )
             filedata = filedata.replace(
                 "/Users/me/awesome-course/assignment_repos",
-                os.path.join(main_dir, "assignment-template-repos"),
+                os.path.join(main_dir, "template_dir"),
             )
-        with open(os.path.join(course_name, "config.yml"), "w") as file:
+        with open(os.path.join(main_dir, "config.yml"), "w") as file:
             file.write(filedata)
     print(
         """

--- a/abcclassroom/tests/conftest.py
+++ b/abcclassroom/tests/conftest.py
@@ -10,7 +10,7 @@ def default_config():
     config = {
         "template_dir": "test_template",
         "course_materials": "nbgrader",
-        "clone_dir": "student-cloned-repos",
+        "clone_dir": "cloned-repos",
         "extra_files": {
             "testfile.txt": ["line1", "line2"],
             "README.md": ["line1", "line2"],

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -1,6 +1,7 @@
 import os
 import pytest
-from shutil import rmtree
+
+# from shutil import rmtree
 from abcclassroom.quickstart import create_dir_struct as quickstart
 
 
@@ -11,7 +12,6 @@ def test_quickstart_default(tmp_path):
     """
     quickstart(working_dir=tmp_path)
     main_dir = os.path.join(tmp_path, "course_dir")
-    # main_dir = os.path.join(os.getcwd(), "course_dir")
     assert os.path.isdir(main_dir)
     assert os.path.isfile(os.path.join(main_dir, "config.yml"))
     with open(os.path.join(main_dir, "config.yml")) as data:
@@ -22,27 +22,22 @@ def test_quickstart_default(tmp_path):
         )
     assert os.path.isdir(os.path.join(main_dir, "template_dir"))
     assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
-    rmtree(main_dir)
+    # rmtree(main_dir)
 
 
-def test_quickstart_custom_name():
+def test_quickstart_custom_name(tmp_path):
     """
     Test that abc-quickstart works with a custom name.
     """
     custom_name = "pytest_dir_custom_name"
-    quickstart(custom_name)
-    main_dir = os.path.join(os.getcwd(), custom_name)
+    quickstart(custom_name, working_dir=tmp_path)
+    main_dir = os.path.join(tmp_path, custom_name)
+    assert os.path.isdir(main_dir)
+    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
     with open(os.path.join(main_dir, "config.yml")) as data:
-        assert (
-            os.path.isdir(main_dir)
-            and os.path.isdir(os.path.join(main_dir, "template_dir"))
-            and os.path.isdir(os.path.join(main_dir, "clone_dir"))
-            and os.path.isfile(os.path.join(main_dir, "config.yml"))
-            and "python_test_dir_custom_name"
-            and "template_dir"
-            and "clone_dir" in data.read()
-        )
-    rmtree(main_dir)
+        assert custom_name and "template_dir" and "clone_dir" in data.read()
+    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
+    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
 
 
 def test_quickstart_bad_name():
@@ -53,32 +48,31 @@ def test_quickstart_bad_name():
         quickstart("bad name")
 
 
-def test_quickstart_remake_existing():
+def test_quickstart_remake_existing(tmp_path):
     """
     Test that abc-quickstart fails when using the same name for a course twice.
     """
-    quickstart("python_test_dir_custom_name")
-    main_dir = os.path.join(os.getcwd(), "python_test_dir_custom_name")
+    quickstart("python_test_dir_custom_name", working_dir=tmp_path)
+    main_dir = os.path.join(tmp_path, "python_test_dir_custom_name")
     with pytest.raises(ValueError, match="Ooops! "):
-        quickstart("python_test_dir_custom_name")
-    rmtree(main_dir)
+        quickstart("python_test_dir_custom_name", working_dir=tmp_path)
 
 
-def test_quickstart_remove_existing():
+def test_quickstart_remove_existing(tmp_path):
     """
     Test that abc-quickstart doesn't fail when using the same name for a course twice and the -f argument.
     """
-    quickstart("python_test_dir_custom_name")
-    quickstart("python_test_dir_custom_name", True)
-    main_dir = os.path.join(os.getcwd(), "python_test_dir_custom_name")
+    custom_name = "python_test_dir_custom_name"
+    quickstart(custom_name, working_dir=tmp_path)
+    quickstart(custom_name, True, working_dir=tmp_path)
+    main_dir = os.path.join(tmp_path, custom_name)
+    assert os.path.isdir(main_dir)
+    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
     with open(os.path.join(main_dir, "config.yml")) as data:
         assert (
-            os.path.isdir(main_dir)
-            and os.path.isdir(os.path.join(main_dir, "template_dir"))
-            and os.path.isdir(os.path.join(main_dir, "clone_dir"))
-            and os.path.isfile(os.path.join(main_dir, "config.yml"))
-            and "course-name"
+            "course_directory"
             and "template_dir"
             and "clone_dir" in data.read()
         )
-    rmtree(main_dir)
+    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
+    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -1,7 +1,5 @@
 import os
 import pytest
-
-# from shutil import rmtree
 from abcclassroom.quickstart import create_dir_struct as quickstart
 
 
@@ -22,7 +20,6 @@ def test_quickstart_default(tmp_path):
         )
     assert os.path.isdir(os.path.join(main_dir, "template_dir"))
     assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
-    # rmtree(main_dir)
 
 
 def test_quickstart_custom_name(tmp_path):

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -53,7 +53,6 @@ def test_quickstart_remake_existing(tmp_path):
     Test that abc-quickstart fails when using the same name for a course twice.
     """
     quickstart("python_test_dir_custom_name", working_dir=tmp_path)
-    main_dir = os.path.join(tmp_path, "python_test_dir_custom_name")
     with pytest.raises(ValueError, match="Ooops! "):
         quickstart("python_test_dir_custom_name", working_dir=tmp_path)
 

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -9,15 +9,18 @@ def test_quickstart_default(tmp_path):
     "course_dir" main directory and all expected folders and outputs.
     """
     quickstart(working_dir=tmp_path)
+    # check that main dir and config created
     main_dir = os.path.join(tmp_path, "course_dir")
     assert os.path.isdir(main_dir)
     assert os.path.isfile(os.path.join(main_dir, "config.yml"))
+    # check contents of config
     with open(os.path.join(main_dir, "config.yml")) as data:
         assert (
             "course_directory"
             and "template_dir"
             and "clone_dir" in data.read()
         )
+    # check that subdirectories created
     assert os.path.isdir(os.path.join(main_dir, "template_dir"))
     assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
 

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -4,24 +4,24 @@ from shutil import rmtree
 from abcclassroom.quickstart import create_dir_struct as quickstart
 
 
-def test_quickstart_default():
+def test_quickstart_default(tmp_path):
     """
-    Test that the standard run of abc-quickstart creates all expected folders and outputs.
+    Test that abc-quickstart without arguments creates the default
+    "course_dir" main directory and all expected folders and outputs.
     """
-    quickstart()
-    main_dir = os.path.join(os.getcwd(), "course_dir")
+    quickstart(working_dir=tmp_path)
+    main_dir = os.path.join(tmp_path, "course_dir")
+    # main_dir = os.path.join(os.getcwd(), "course_dir")
+    assert os.path.isdir(main_dir)
+    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
     with open(os.path.join(main_dir, "config.yml")) as data:
         assert (
-            os.path.isdir(main_dir)
-            and os.path.isdir(
-                os.path.join(main_dir, "assignment-template-repos")
-            )
-            and os.path.isdir(os.path.join(main_dir, "student-cloned-repos"))
-            and os.path.isfile(os.path.join(main_dir, "config.yml"))
-            and "course-name"
-            and "assignment-template-repos"
-            and "student-cloned-repos" in data.read()
+            "course_directory"
+            and "template_dir"
+            and "clone_dir" in data.read()
         )
+    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
+    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
     rmtree(main_dir)
 
 
@@ -29,19 +29,18 @@ def test_quickstart_custom_name():
     """
     Test that abc-quickstart works with a custom name.
     """
-    quickstart("python_test_dir_custom_name")
-    main_dir = os.path.join(os.getcwd(), "python_test_dir_custom_name")
+    custom_name = "pytest_dir_custom_name"
+    quickstart(custom_name)
+    main_dir = os.path.join(os.getcwd(), custom_name)
     with open(os.path.join(main_dir, "config.yml")) as data:
         assert (
             os.path.isdir(main_dir)
-            and os.path.isdir(
-                os.path.join(main_dir, "assignment-template-repos")
-            )
-            and os.path.isdir(os.path.join(main_dir, "student-cloned-repos"))
+            and os.path.isdir(os.path.join(main_dir, "template_dir"))
+            and os.path.isdir(os.path.join(main_dir, "clone_dir"))
             and os.path.isfile(os.path.join(main_dir, "config.yml"))
             and "python_test_dir_custom_name"
-            and "assignment-template-repos"
-            and "student-cloned-repos" in data.read()
+            and "template_dir"
+            and "clone_dir" in data.read()
         )
     rmtree(main_dir)
 
@@ -75,13 +74,11 @@ def test_quickstart_remove_existing():
     with open(os.path.join(main_dir, "config.yml")) as data:
         assert (
             os.path.isdir(main_dir)
-            and os.path.isdir(
-                os.path.join(main_dir, "assignment-template-repos")
-            )
-            and os.path.isdir(os.path.join(main_dir, "student-cloned-repos"))
+            and os.path.isdir(os.path.join(main_dir, "template_dir"))
+            and os.path.isdir(os.path.join(main_dir, "clone_dir"))
             and os.path.isfile(os.path.join(main_dir, "config.yml"))
             and "course-name"
-            and "assignment-template-repos"
-            and "student-cloned-repos" in data.read()
+            and "template_dir"
+            and "clone_dir" in data.read()
         )
     rmtree(main_dir)


### PR DESCRIPTION
We changed the name of some of the config options, which was causing the quickstart tests to fail. This PR also modifies the quickstart tests to use the pytest tmp_path fixture rather than creating test directories in the abcclassroom directory (addresses issue #151 ).