### PR TITLE
Quickstart bug fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Update quickstart to use sample config and config functions (@kcranston, #160, #142)
 
 ## [0.0.14]
 * Fix bug with adding assignments to config (@kcranston, #161)

--- a/abcclassroom/config.py
+++ b/abcclassroom/config.py
@@ -108,7 +108,7 @@ def write_config(config, configpath=None):
 def get_config_option(config, option, required=True):
     """
     Get an option (value of key) from provided config dictionary. If the key
-    does not exist, exit with KeyError (required=True) or return None  (required=False).
+    does not exist, exit with KeyError (required=True) or return None (required=False).
     """
     try:
         value = config[option]

--- a/abcclassroom/example-data/config.yml
+++ b/abcclassroom/example-data/config.yml
@@ -22,7 +22,7 @@ course_materials: nbgrader
 # Assumed to be relative to course_dir unless you enter an absolute path
 # (i.e. starting with '/' on Linux or OS X or with 'C:' on Windows). None of
 # the parent directories of clone_dir should be git repositories.
-clone_dir: cloned_dirs
+clone_dir: cloned_repos
 
 # Path to the assignment template repositories. Again, none of
 # the parent directories should be a git repo. Assumed to be relative to

--- a/abcclassroom/example-data/readme.md
+++ b/abcclassroom/example-data/readme.md
@@ -4,8 +4,8 @@ This directory contains two files.
 
 **config.yml**
 
-The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. Because this file is used by **abc-classroom**, do not modify this file directly. If you aren't using `abc-quickstart` and you want to create your own config, make a copy and modify the copy.
+The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. Because this file is used by **abc-classroom**, do not modify this file directly. If you aren't using `abc-quickstart` and you want to create your own config, make a copy, place the copy in your course directory, and modify the copy.
 
 **sample_roster.csv**
 
-A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is not used by **abc-classroom** directly. It is only provided here for reference. 
+A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is not used by **abc-classroom** directly. It is only provided here for reference.

--- a/abcclassroom/example-data/readme.md
+++ b/abcclassroom/example-data/readme.md
@@ -1,0 +1,11 @@
+# Example data for abc-classroom
+
+This directory contains two files.
+
+**config.yml**
+
+The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. Because this file is used by **abc-classroom**, do not modify this file directly. If you aren't using `abc-quickstart` and you want to create your own config, make a copy and modify the copy.
+
+**sample_roster.csv**
+
+A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is not used by **abc-classroom** directly. It is only provided here for reference. 

--- a/abcclassroom/example-data/readme.md
+++ b/abcclassroom/example-data/readme.md
@@ -2,10 +2,12 @@
 
 This directory contains two files.
 
-**config.yml**
+## config.yml
+
+**Do not modify this file in this location**
 
 The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. Because this file is used by **abc-classroom**, do not modify this file directly. If you aren't using `abc-quickstart` and you want to create your own config, make a copy, place the copy in your course directory, and modify the copy.
 
-**sample_roster.csv**
+## sample_roster.csv
 
 A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is not used by **abc-classroom** directly. It is only provided here for reference.

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -5,6 +5,7 @@ abc-classroom.quickstart
 """
 
 import os
+from pathlib import Path
 from shutil import copy, rmtree
 from . import config as cf
 from abcclassroom import __file__
@@ -12,9 +13,9 @@ from abcclassroom import __file__
 
 def path_to_example(dataset):
     """
-    Construct a file path to an example dataset.
-    This file defines helper functions to access data files in this directory,
-    to support examples. Adapted from the PySAL package.
+    Construct a file path to an example dataset, assuming the dataset is
+    contained in the 'example-data' directory of the abc-classroom package.
+    Adapted from the PySAL package.
 
     Parameters
     ----------
@@ -23,24 +24,26 @@ def path_to_example(dataset):
 
     Returns
     -------
-    string
-        A file path (string) to the dataset
+    Path object
+        A concrete Path object to the dataset
     """
-    abcclassroom_path = os.path.split(__file__)[0]
-    data_dir = os.path.join(abcclassroom_path, "example-data")
-    data_files = os.listdir(data_dir)
-    if dataset not in data_files:
-        raise KeyError(dataset + " not found in abc-classroom example data.")
-    return os.path.join(data_dir, dataset)
+    abcclassroom_path = Path(__file__).parent
+    dataset_path = Path(abcclassroom_path, "example-data", dataset)
+    if not dataset_path.exists():
+        raise FileNotFoundError(
+            dataset + " not found in abc-classroom example-data directory."
+        )
+    return dataset_path
 
 
-def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
+def create_dir_struct(course_name="course_dir", force=False, working_dir=None):
     """
     Create a directory structure that can be used to start an abc-classroom
     course. This includes a main directory, two sub directories for templates
     and cloned files, and a start to a configuration file.
 
-    Implementation of abc-quickstart script; called directly from main.
+    This is the tmplementation of athe bc-quickstart script; it is called
+    directly from main.
     """
     # Making sure the sample configuration file is where it's supposed to be.
     config = path_to_example("config.yml")
@@ -62,7 +65,7 @@ def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
     if working_dir is None:
         working_dir = os.getcwd()
     main_dir = os.path.join(working_dir, course_name)
-    if f and os.path.isdir(main_dir):
+    if force and os.path.isdir(main_dir):
         rmtree(main_dir)
     # Make sure that the main_dir doesn't exist already
     if os.path.isdir(main_dir):
@@ -71,8 +74,8 @@ def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
             Ooops! It looks like the directory {} already exists on your
             computer. You might have already run quickstart in this directory.
             Consider using a different course name, deleting the existing
-            directory, or running quikstart with the -f flag to overwrite the
-            existing directory if you do not need it.""".format(
+            directory, or running quikstart with the -f flag to force overwrite
+            the existing directory.""".format(
                 course_name
             )
         )
@@ -106,7 +109,7 @@ def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
         Created abc-classroom directory structure in '{}',
         including template and cloning directories and a configuration file,
         'config.yml'. To proceed, please create / move your sample roster
-        and course_materials directory into '{}' and check the config file 
+        and course_materials directory into '{}' and check the config file
         settings.""".format(
             main_dir, course_name
         )

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -6,6 +6,7 @@ abc-classroom.quickstart
 
 import os
 from shutil import copy, rmtree
+from . import config as cf
 from abcclassroom import __file__
 
 
@@ -35,19 +36,26 @@ def path_to_example(dataset):
 
 def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
     """
-    Create a directory structure that can be used to start an abc-classroom course. This includes a main directory,
-    two sub directories for templates and cloned files, and a start to a configuration file.
+    Create a directory structure that can be used to start an abc-classroom
+    course. This includes a main directory, two sub directories for templates
+    and cloned files, and a start to a configuration file.
+
+    Implementation of abc-quickstart script; called directly from main.
     """
-    # Making sure the configuration file is where it's supposed to be.
+    # Making sure the sample configuration file is where it's supposed to be.
     config = path_to_example("config.yml")
     if not os.path.exists(config):
         raise ValueError(
-            "config.yml configuration file can't be located, please ensure abc-classroom has been installed correctly"
+            """Sample config.yml configuration file can't be located at {},
+            please ensure abc-classroom has been installed
+            correctly""".format(
+                config
+            )
         )
     # Assigning the custom folder name if applicable
     if " " in course_name:
         raise ValueError(
-            "Spaces not allowed in custom course name {}. Please use hyphens instead.".format(
+            "Spaces not allowed in custom course name: {}. Please use hyphens instead.".format(
                 course_name
             )
         )
@@ -60,9 +68,11 @@ def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
     if os.path.isdir(main_dir):
         raise ValueError(
             """
-            Ooops! It looks like the directory {} already exists on your computer. You might have already
-            run quickstart in this directory. Consider using another course name or deleting the existing directory
-            if you do not need it.""".format(
+            Ooops! It looks like the directory {} already exists on your
+            computer. You might have already run quickstart in this directory.
+            Consider using a different course name, deleting the existing
+            directory, or running quikstart with the -f flag to overwrite the
+            existing directory if you do not need it.""".format(
                 course_name
             )
         )
@@ -93,9 +103,11 @@ def create_dir_struct(course_name="course_dir", f=False, working_dir=None):
             file.write(filedata)
     print(
         """
-        Directory structure created to begin using abc-classroom at {}.
-        All directories needed and a configuration file to modify have been created. To proceed, please
-        move your sample roster and course_materials directory into {} created by quickstart.""".format(
+        Created abc-classroom directory structure in '{}',
+        including template and cloning directories and a configuration file,
+        'config.yml'. To proceed, please create / move your sample roster
+        and course_materials directory into '{}' and check the config file 
+        settings.""".format(
             main_dir, course_name
         )
     )

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -30,29 +30,28 @@ def path_to_example(dataset):
     abcclassroom_path = Path(__file__).parent
     dataset_path = Path(abcclassroom_path, "example-data", dataset)
     if not dataset_path.exists():
-        raise FileNotFoundError(
-            dataset + " not found in abc-classroom example-data directory."
-        )
+        raise FileNotFoundError(dataset_path)
     return dataset_path
 
 
-def create_dir_struct(course_name="course_dir", force=False, working_dir=None):
+def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
     """
     Create a directory structure that can be used to start an abc-classroom
     course. This includes a main directory, two sub directories for templates
     and cloned files, and a start to a configuration file.
 
-    This is the tmplementation of athe bc-quickstart script; it is called
+    This is the tmplementation of the abc-quickstart script; it is called
     directly from main.
     """
     # Making sure the sample configuration file is where it's supposed to be.
-    config = path_to_example("config.yml")
-    if not os.path.exists(config):
-        raise ValueError(
-            """Sample config.yml configuration file can't be located at {},
-            please ensure abc-classroom has been installed
-            correctly""".format(
-                config
+    try:
+        config_path = path_to_example("config.yml")
+    except FileNotFoundError as err:
+        print(
+            """Sample config.yml configuration file cannot be located at {},
+        please ensure abc-classroom has been installed
+        correctly""".format(
+                err
             )
         )
     # Assigning the custom folder name if applicable
@@ -64,51 +63,69 @@ def create_dir_struct(course_name="course_dir", force=False, working_dir=None):
         )
     if working_dir is None:
         working_dir = os.getcwd()
-    main_dir = os.path.join(working_dir, course_name)
-    if force and os.path.isdir(main_dir):
-        rmtree(main_dir)
-    # Make sure that the main_dir doesn't exist already
-    if os.path.isdir(main_dir):
-        raise ValueError(
-            """
-            Ooops! It looks like the directory {} already exists on your
-            computer. You might have already run quickstart in this directory.
-            Consider using a different course name, deleting the existing
-            directory, or running quikstart with the -f flag to force overwrite
-            the existing directory.""".format(
-                course_name
+    # main_dir = os.path.join(working_dir, course_name)
+    main_dir = Path(working_dir, course_name)
+    # Check if the main_dir doesn't exist already
+    if main_dir.is_dir():
+        if force:
+            rmtree(main_dir)
+        else:
+            raise FileExistsError(
+                """
+                Ooops! It looks like the directory {} already exists on your
+                computer. You might have already run quickstart in this directory.
+                Consider using a different course name, deleting the existing
+                directory, or running quikstart with the -f flag to force overwrite
+                the existing directory.""".format(
+                    course_name
+                )
             )
-        )
-    # Making all the needed directories and subdirectories, and creating the configuration file.
-    dir_names = [
-        main_dir,
-        os.path.join(main_dir, "clone_dir"),
-        os.path.join(main_dir, "template_dir"),
-    ]
-    for directories in dir_names:
-        os.mkdir(directories)
-    copy(config, main_dir)
-    if course_name:
-        with open(os.path.join(main_dir, "config.yml"), "r") as file:
-            filedata = file.read()
-            filedata = filedata.replace(
-                "/Users/karen/awesome-course", main_dir
-            )
-            filedata = filedata.replace(
-                "/Users/me/awesome-course/cloned_dirs",
-                os.path.join(main_dir, "clone_dir"),
-            )
-            filedata = filedata.replace(
-                "/Users/me/awesome-course/assignment_repos",
-                os.path.join(main_dir, "template_dir"),
-            )
-        with open(os.path.join(main_dir, "config.yml"), "w") as file:
-            file.write(filedata)
+    # make the main course directory and copy the config file there
+    main_dir.mkdir()
+    copy(config_path, main_dir)
+
+    # now we can use config functions to read / write config
+    config = cf.get_config(main_dir)
+    config["course_directory"] = str(main_dir)
+    cf.write_config(config, main_dir)
+    clone_dir = cf.get_config_option(config, "clone_dir")
+    template_dir = cf.get_config_option(config, "template_dir")
+
+    # make the required subdirectories
+    Path(main_dir, clone_dir).mkdir()
+    Path(main_dir, template_dir).mkdir()
+
+    # Making all the needed directories and subdirectories, and creating the
+    # configuration file.
+    # dir_paths = [
+    #     main_dir,
+    #     Path(main_dir, "clone_dir"),
+    #     Path(main_dir, "template_dir"),
+    # ]
+    # for directory in dir_paths:
+    #     directory.mkdir()
+    # copy(config, main_dir)
+    # if course_name:
+    #     with open(os.path.join(main_dir, "config.yml"), "r") as file:
+    #         filedata = file.read()
+    #         filedata = filedata.replace(
+    #             "/Users/karen/awesome-course", main_dir
+    #         )
+    #         filedata = filedata.replace(
+    #             "/Users/me/awesome-course/cloned_dirs",
+    #             os.path.join(main_dir, "clone_dir"),
+    #         )
+    #         filedata = filedata.replace(
+    #             "/Users/me/awesome-course/assignment_repos",
+    #             os.path.join(main_dir, "template_dir"),
+    #         )
+    #     with open(os.path.join(main_dir, "config.yml"), "w") as file:
+    #         file.write(filedata)
     print(
         """
         Created abc-classroom directory structure in '{}',
-        including template and cloning directories and a configuration file,
-        'config.yml'. To proceed, please create / move your sample roster
+        including template and clone directories and a configuration file,
+        'config.yml'. To proceed, please create / move your course roster
         and course_materials directory into '{}' and check the config file
         settings.""".format(
             main_dir, course_name

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -63,8 +63,8 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
         )
     if working_dir is None:
         working_dir = os.getcwd()
-    # main_dir = os.path.join(working_dir, course_name)
     main_dir = Path(working_dir, course_name)
+
     # Check if the main_dir doesn't exist already
     if main_dir.is_dir():
         if force:
@@ -95,32 +95,6 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
     Path(main_dir, clone_dir).mkdir()
     Path(main_dir, template_dir).mkdir()
 
-    # Making all the needed directories and subdirectories, and creating the
-    # configuration file.
-    # dir_paths = [
-    #     main_dir,
-    #     Path(main_dir, "clone_dir"),
-    #     Path(main_dir, "template_dir"),
-    # ]
-    # for directory in dir_paths:
-    #     directory.mkdir()
-    # copy(config, main_dir)
-    # if course_name:
-    #     with open(os.path.join(main_dir, "config.yml"), "r") as file:
-    #         filedata = file.read()
-    #         filedata = filedata.replace(
-    #             "/Users/karen/awesome-course", main_dir
-    #         )
-    #         filedata = filedata.replace(
-    #             "/Users/me/awesome-course/cloned_dirs",
-    #             os.path.join(main_dir, "clone_dir"),
-    #         )
-    #         filedata = filedata.replace(
-    #             "/Users/me/awesome-course/assignment_repos",
-    #             os.path.join(main_dir, "template_dir"),
-    #         )
-    #     with open(os.path.join(main_dir, "config.yml"), "w") as file:
-    #         file.write(filedata)
     print(
         """
         Created abc-classroom directory structure in '{}',

--- a/abcclassroom/tests/test_assignment_template.py
+++ b/abcclassroom/tests/test_assignment_template.py
@@ -112,7 +112,7 @@ def test_copy_assignment_files(default_config, tmp_path):
     abctemplate.copy_assignment_files(
         default_config, template_repo, assignment
     )
-    assert os.listdir(nbpath) == os.listdir(template_repo)
+    assert os.listdir(nbpath).sort() == os.listdir(template_repo).sort()
 
 
 def test_copy_assignment_files_fails_nodir(default_config, tmp_path):

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -1,6 +1,8 @@
 import os
 import pytest
+from pathlib import Path
 import abcclassroom.quickstart as quickstart
+import abcclassroom.config as cf
 
 
 def test_path_to_example():
@@ -17,23 +19,22 @@ def test_path_to_example():
 def test_quickstart_default(tmp_path):
     """
     Test that abc-quickstart without arguments creates the default
-    "course_dir" main directory and all expected folders and outputs.
+    "abc_course" main directory, config file and two subdirectories.
     """
     quickstart.create_dir_struct(working_dir=tmp_path)
     # check that main dir and config created
-    main_dir = os.path.join(tmp_path, "course_dir")
-    assert os.path.isdir(main_dir)
-    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
+    main_dir = Path(tmp_path, "abc_course")
+    assert main_dir.is_dir()
+    assert Path(main_dir, "config.yml").is_file()
     # check contents of config
-    with open(os.path.join(main_dir, "config.yml")) as data:
-        assert (
-            "course_directory"
-            and "template_dir"
-            and "clone_dir" in data.read()
-        )
+    config = cf.get_config(main_dir)
+    assert cf.get_config_option(config, "course_directory") == str(main_dir)
+
     # check that subdirectories created
-    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
-    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
+    template_dir = cf.get_config_option(config, "template_dir")
+    assert Path(main_dir, template_dir).is_dir()
+    clone_dir = cf.get_config_option(config, "clone_dir")
+    assert Path(main_dir, clone_dir).is_dir()
 
 
 def test_quickstart_custom_name(tmp_path):
@@ -42,13 +43,18 @@ def test_quickstart_custom_name(tmp_path):
     """
     custom_name = "pytest_dir_custom_name"
     quickstart.create_dir_struct(custom_name, working_dir=tmp_path)
-    main_dir = os.path.join(tmp_path, custom_name)
-    assert os.path.isdir(main_dir)
-    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
-    with open(os.path.join(main_dir, "config.yml")) as data:
-        assert custom_name and "template_dir" and "clone_dir" in data.read()
-    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
-    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
+    main_dir = Path(tmp_path, custom_name)
+    assert main_dir.is_dir()
+    assert Path(main_dir, "config.yml").is_file()
+    # check contents of config
+    config = cf.get_config(main_dir)
+    assert cf.get_config_option(config, "course_directory") == str(main_dir)
+
+    # check that subdirectories created
+    template_dir = cf.get_config_option(config, "template_dir")
+    assert Path(main_dir, template_dir).is_dir()
+    clone_dir = cf.get_config_option(config, "clone_dir")
+    assert Path(main_dir, clone_dir).is_dir()
 
 
 def test_quickstart_bad_name():
@@ -66,7 +72,7 @@ def test_quickstart_remake_existing(tmp_path):
     quickstart.create_dir_struct(
         "python_test_dir_custom_name", working_dir=tmp_path
     )
-    with pytest.raises(ValueError, match="Ooops! "):
+    with pytest.raises(FileExistsError, match="Ooops! "):
         quickstart.create_dir_struct(
             "python_test_dir_custom_name", working_dir=tmp_path
         )
@@ -74,19 +80,12 @@ def test_quickstart_remake_existing(tmp_path):
 
 def test_quickstart_remove_existing(tmp_path):
     """
-    Test that abc-quickstart doesn't fail when using the same name for a course twice and the -f argument.
+    Test that abc-quickstart doesn't fail when using the same name for a course
+    twice with the -f argument.
     """
     custom_name = "python_test_dir_custom_name"
     quickstart.create_dir_struct(custom_name, working_dir=tmp_path)
     quickstart.create_dir_struct(custom_name, True, working_dir=tmp_path)
-    main_dir = os.path.join(tmp_path, custom_name)
-    assert os.path.isdir(main_dir)
-    assert os.path.isfile(os.path.join(main_dir, "config.yml"))
-    with open(os.path.join(main_dir, "config.yml")) as data:
-        assert (
-            "course_directory"
-            and "template_dir"
-            and "clone_dir" in data.read()
-        )
-    assert os.path.isdir(os.path.join(main_dir, "template_dir"))
-    assert os.path.isdir(os.path.join(main_dir, "clone_dir"))
+    main_dir = Path(tmp_path, custom_name)
+    assert main_dir.is_dir()
+    assert Path(main_dir, "config.yml").is_file()

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -1,6 +1,17 @@
 import os
 import pytest
-from abcclassroom.quickstart import create_dir_struct as quickstart
+import abcclassroom.quickstart as quickstart
+
+
+def test_path_to_example():
+    # with filename that should exist
+    filename = "config.yml"
+    config_path = quickstart.path_to_example(filename)
+
+    # with filename that doesn't exist
+    filename = "filethatdoesntexist.txt"
+    with pytest.raises(FileNotFoundError):
+        config_path = quickstart.path_to_example(filename)
 
 
 def test_quickstart_default(tmp_path):
@@ -8,7 +19,7 @@ def test_quickstart_default(tmp_path):
     Test that abc-quickstart without arguments creates the default
     "course_dir" main directory and all expected folders and outputs.
     """
-    quickstart(working_dir=tmp_path)
+    quickstart.create_dir_struct(working_dir=tmp_path)
     # check that main dir and config created
     main_dir = os.path.join(tmp_path, "course_dir")
     assert os.path.isdir(main_dir)
@@ -30,7 +41,7 @@ def test_quickstart_custom_name(tmp_path):
     Test that abc-quickstart works with a custom name.
     """
     custom_name = "pytest_dir_custom_name"
-    quickstart(custom_name, working_dir=tmp_path)
+    quickstart.create_dir_struct(custom_name, working_dir=tmp_path)
     main_dir = os.path.join(tmp_path, custom_name)
     assert os.path.isdir(main_dir)
     assert os.path.isfile(os.path.join(main_dir, "config.yml"))
@@ -45,16 +56,20 @@ def test_quickstart_bad_name():
     Test that abc-quickstart fails with a improperly formatted name.
     """
     with pytest.raises(ValueError, match="Spaces not"):
-        quickstart("bad name")
+        quickstart.create_dir_struct("bad name")
 
 
 def test_quickstart_remake_existing(tmp_path):
     """
     Test that abc-quickstart fails when using the same name for a course twice.
     """
-    quickstart("python_test_dir_custom_name", working_dir=tmp_path)
+    quickstart.create_dir_struct(
+        "python_test_dir_custom_name", working_dir=tmp_path
+    )
     with pytest.raises(ValueError, match="Ooops! "):
-        quickstart("python_test_dir_custom_name", working_dir=tmp_path)
+        quickstart.create_dir_struct(
+            "python_test_dir_custom_name", working_dir=tmp_path
+        )
 
 
 def test_quickstart_remove_existing(tmp_path):
@@ -62,8 +77,8 @@ def test_quickstart_remove_existing(tmp_path):
     Test that abc-quickstart doesn't fail when using the same name for a course twice and the -f argument.
     """
     custom_name = "python_test_dir_custom_name"
-    quickstart(custom_name, working_dir=tmp_path)
-    quickstart(custom_name, True, working_dir=tmp_path)
+    quickstart.create_dir_struct(custom_name, working_dir=tmp_path)
+    quickstart.create_dir_struct(custom_name, True, working_dir=tmp_path)
     main_dir = os.path.join(tmp_path, custom_name)
     assert os.path.isdir(main_dir)
     assert os.path.isfile(os.path.join(main_dir, "config.yml"))

--- a/abcclassroom/tests/test_quickstart.py
+++ b/abcclassroom/tests/test_quickstart.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from pathlib import Path
 import abcclassroom.quickstart as quickstart
@@ -9,6 +8,9 @@ def test_path_to_example():
     # with filename that should exist
     filename = "config.yml"
     config_path = quickstart.path_to_example(filename)
+    # don't check the full path here because the code uses __file__, which
+    # won't be the same when running tests
+    assert Path(config_path).name == filename
 
     # with filename that doesn't exist
     filename = "filethatdoesntexist.txt"

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -77,10 +77,12 @@ To create a new course:
 This will:
 
 1. Create a course directory named whatever you called your ``course-name`` variable
-2. Create several other directories required to store homework assignment folders
+2. Create two other directories required to store template repositories
    and cloned student repositories.
-3. Creates a sample ``config.yml`` file that can be modified to run the program for your classroom. ``abc-quickstart`` has two arguments that can be used to modify its functionality.
+3. Creates a sample ``config.yml`` file that can be modified to run the program for your classroom.
 
-Run ``abc-quickstart -h`` to see options. If you already have a directory called ``course-name``, then ``abc-quickstart`` will fail. If you want to overwrite this directory, run ``abc-quickstart -f course-name``.
+If you already have a directory called ``course-name``, then ``abc-quickstart`` will fail. If you want to overwrite this directory, run ``abc-quickstart -f course-name``.
+
+Run ``abc-quickstart -h`` to see options.
 
 Now, you can set up the directory where you manage your course materials: :doc:`course-materials`.


### PR DESCRIPTION
This addresses the quickstart bug in #160 (where quickstart is hard-coding the directory names rather than pulling them from the sample config). It also modifies the quickstart code to use the config functions (#142). 