### PR TITLE
Better feedback error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Check whether local repo has uncommitted changes before trying to commit (@kcranston, #182)
 * Update quickstart to use sample config and config functions (@kcranston, #160, #142)
 
 ## [0.0.14]

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -38,18 +38,21 @@ def copy_feedback(args):
                 source_files = Path(feedback_dir, student, assignment).glob(
                     "*"
                 )
-                # if len(list(source_files)) == 0:
-                #     print(
-                #         "No feedback files found for student {}".format(
-                #             student
-                #         )
-                #     )
-                #     continue
-                # if there are files, copy them and do git / github stuff
                 repo = "{}-{}".format(assignment, student)
                 destination_dir = Path(clone_dir, repo)
+                if not destination_dir.is_dir():
+                    print(
+                        "Local student repository {} does not exist; skipping student".format(
+                            destination_dir
+                        )
+                    )
+                    continue
                 for f in source_files:
-                    print("copying {} to {}".format(f, destination_dir))
+                    print(
+                        "Copying {} to {}".format(
+                            f.relative_to(course_dir), destination_dir
+                        )
+                    )
                     shutil.copy(f, destination_dir)
                 github.commit_all_changes(
                     destination_dir,
@@ -59,5 +62,5 @@ def copy_feedback(args):
                     github.push_to_github(destination_dir)
 
     except FileNotFoundError as err:
-        print("Cannot find roster file".format(roster_filename))
-        print(err)
+        print("Missing file or directory:")
+        print(" ", err)

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -144,15 +144,21 @@ def get_commit_message():
 
 
 def commit_all_changes(directory, msg=None):
+    """Run git add, git commit on a given directory. Checks git status
+    first and does nothing if no changes.
+    """
     if msg is None:
         raise ValueError("Commit message can not be empty.")
-
-    _call_git("add", "*", directory=directory)
-    _call_git("commit", "-a", "-m", msg, directory=directory)
+    if repo_changed(directory):
+        _call_git("add", "*", directory=directory)
+        _call_git("commit", "-a", "-m", msg, directory=directory)
+    else:
+        print("No changes in repository {}; doing nothing".format(directory))
 
 
 def init_and_commit(directory, custom_message=False):
-    """Run git init, git add, git commit on given directory.
+    """Run git init, git add, git commit on given directory. Checks git status
+    first and does nothing if no changes.
     """
     # local git things - initialize, add, commit
     # note that running git init on an existing repo is safe, so no need


### PR DESCRIPTION
This fixes the error-not-error that @jlpalomino reported in issue #182 by adding a check on whether the git repo has uncommitted changes before trying to commit. (The reason that the template script wasn't showing the same behaviour is that it uses a different method that bundles init and commit, which already includes this check). 
