### PR TITLE
add python 3.8 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ matrix:
   - os: linux
     dist: xenial
     python: 3.7
-    env: TOXENV=py37,black,docs
+    env: TOXENV=py37
+  - os: linux
+    dist: xenial
+    python: 3.8
+    env: TOXENV=py38,black,docs
   - os: osx
     language: generic
 install:


### PR DESCRIPTION
should just be a small fix to build off of python 3.8 given we're using it in our classes now. 