### PR TITLE
Clean html feedback reports of hidden tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [Unreleased]
 ------------
+- Add ``scrub`` argument to abc-feedback to clean hidden tests from html (@lwasser, #290, #238)
 
 [0.1.6]
 ------------

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -140,6 +140,11 @@ def feedback():
         help="""Also pushes files to student repositories on GitHub
         (default = False; only copies files to local repos)""",
     )
+    parser.add_argument(
+        "--scrub",
+        action="store_true",
+        help="""Cleans out hidden tests from notebooks when used.""",
+    )
     args = parser.parse_args()
     fdback.copy_feedback(args)
 

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -118,13 +118,15 @@ def copy_feedback(args):
 
     Parameters
     ----------
-    args: string
+    args : string
         Command line argument for the copy_feedback function. Options include:
         assignment: Assignment name
-        github: a flag to push to GitHub vs only commit the change
-        scrub: boolean
-            if true (exists), remove hidden tests from the html output
-            before moving it to the student directory
+    github : boolean (default = False)
+        If true, or --github used, push to GitHub. Otherwise only commit
+        the change
+    scrub : boolean (default = False)
+        If true (exists), remove hidden tests from the html output
+        before moving it to the student directory
 
     Returns
     -------

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -1,7 +1,6 @@
 """
 abc-classroom.feedback
 ======================
-
 """
 
 from pathlib import Path

--- a/abcclassroom/scrub_feedback.py
+++ b/abcclassroom/scrub_feedback.py
@@ -31,21 +31,23 @@ def scrub_feedback(html_path):
     html-file: A cleaned html file without the hidden tests.
         The original file will be overwritten.
     """
-    with codecs.open(file, 'r') as html_file:
+    with codecs.open(html_path, "r") as html_file:
         orig_html_feedback = html_file.read()
 
     # Hide hidden tests
     html_clean = re.sub(
         r'<span class="c1">### BEGIN HIDDEN TESTS<\/span>[\w\W]*?'
         r'<span class="c1">### END HIDDEN TESTS<\/span>',
-        '',
-        orig_html_feedback)
+        "",
+        orig_html_feedback,
+    )
     # Just in case we use just one pound sign
     html_clean = re.sub(
         r'<span class="c1"># BEGIN HIDDEN TESTS<\/span>[\w\W]*?'
         r'<span class="c1"># END HIDDEN TESTS<\/span>',
-        '',
-        html_clean)
+        "",
+        html_clean,
+    )
 
     # Not sure we will need this
     # Hide the traceback (which includes parts of the hidden tests)
@@ -56,16 +58,7 @@ def scrub_feedback(html_path):
     #     r'\1\2',
     #     orig_html_feedback)
 
-    # Write the file - do I need a return?
-    with open("new-graded-file.html", "w") as cleaned_html:
+    # Write the file - currently this overwrites the existing html output
+    # We could consider a different approach
+    with open(html_path, "w") as cleaned_html:
         cleaned_html.write(html_clean)
-
-
-def clean_feedback_html():
-    # Go through each html file in the feedback dir and run scrub_feedback
-
-
-def clean_feedback(args):
-    """if we need a cli - this might be better as a option for abc-feedback"""
-    assignment_name = args.assignment
-    clean_feedback_html(assignment_name)

--- a/abcclassroom/scrub_feedback.py
+++ b/abcclassroom/scrub_feedback.py
@@ -1,0 +1,71 @@
+"""
+abc-classroom.scrub-feedback
+============================
+"""
+
+import re
+import codecs
+
+# This approach borrowed
+# from https://github.com/jupyter/nbgrader/issues/1156#issuecomment-502097507
+
+
+def scrub_feedback(html_path):
+    """Scrub out hidden tests from nbgrader html feedback pages.
+
+    We use this to remove hidden tests given all of the nbgrader grade
+    information including comments are only stored in the DB. Therefore
+    it is more work than expected to generate a nice custom report.
+
+    This will remove all html between ### BEGIN HIDDEN TESTS and ### END
+    HIDDEN TESTS. Because I think we sometimes only use one # sign i may add a
+    second catch for this.
+
+    Parameters
+    ----------
+    html_path : string
+        Path to HTML file to be cleaned.
+
+    Returns
+    -------
+    html-file: A cleaned html file without the hidden tests.
+        The original file will be overwritten.
+    """
+    with codecs.open(file, 'r') as html_file:
+        orig_html_feedback = html_file.read()
+
+    # Hide hidden tests
+    html_clean = re.sub(
+        r'<span class="c1">### BEGIN HIDDEN TESTS<\/span>[\w\W]*?'
+        r'<span class="c1">### END HIDDEN TESTS<\/span>',
+        '',
+        orig_html_feedback)
+    # Just in case we use just one pound sign
+    html_clean = re.sub(
+        r'<span class="c1"># BEGIN HIDDEN TESTS<\/span>[\w\W]*?'
+        r'<span class="c1"># END HIDDEN TESTS<\/span>',
+        '',
+        html_clean)
+
+    # Not sure we will need this
+    # Hide the traceback (which includes parts of the hidden tests)
+    # html = re.sub(
+    #     r'(<div class="output_subarea output_text output_error">\n<pre>\n)
+    #     (?:(?!<\/div>)[\w\W])*(
+    #     <span class="ansi-red-intense-fg ansi-bold">[\w\W]*?<\/pre>)',
+    #     r'\1\2',
+    #     orig_html_feedback)
+
+    # Write the file - do I need a return?
+    with open("new-graded-file.html", "w") as cleaned_html:
+        cleaned_html.write(html_clean)
+
+
+def clean_feedback_html():
+    # Go through each html file in the feedback dir and run scrub_feedback
+
+
+def clean_feedback(args):
+    """if we need a cli - this might be better as a option for abc-feedback"""
+    assignment_name = args.assignment
+    clean_feedback_html(assignment_name)

--- a/abcclassroom/scrub_feedback.py
+++ b/abcclassroom/scrub_feedback.py
@@ -28,7 +28,7 @@ def scrub_feedback(html_path):
 
     Returns
     -------
-    html-file: A cleaned html file without the hidden tests.
+    html-file : A cleaned html file without the hidden tests.
         The original file will be overwritten.
     """
     with codecs.open(html_path, "r") as html_file:

--- a/docs/api/abcclassroom.rst
+++ b/docs/api/abcclassroom.rst
@@ -20,5 +20,6 @@ Submodules
    abcclassroom.notebook
    abcclassroom.ok
    abcclassroom.quickstart
+   abcclassroom.scrub_feedback
    abcclassroom.template
    abcclassroom.utils

--- a/docs/api/abcclassroom.scrub_feedback.rst
+++ b/docs/api/abcclassroom.scrub_feedback.rst
@@ -1,0 +1,4 @@
+.. automodule:: abcclassroom.scrub_feedback
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/collect-grade-assignments/feedback.rst
+++ b/docs/collect-grade-assignments/feedback.rst
@@ -21,8 +21,26 @@ Note that when you use the ``--github`` flag, the files are added to the repo as
 direct comment (not a pull request). So you will want to tell the students to
 check their repo after pushing out the feedback files.
 
-By default ``abc-feedback`` only copies the files to each cloned student repo
-in your local directory.
+By default ``abc-feedback`` only copies the files to each cloned student repo,
+and commits the changes in your local directory. It only pushes to github if
+you use the ``--github`` flag.
+
+Remove Hidden Tests in Html Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are using ``nbgrader`` to create your feedback reports, all of the hidden tests
+(which will likely include the assignment answers) will be included in the default
+feedback report. ``Nbgrader`` relies on a database where all comments and grades are
+stored. If you wish to remove the hidden tests from your output html files, you
+can use the ``--scrub`` argument. Scrub will remove all code as follows::
+
+    ### BEGIN HIDDEN TESTS
+    # code here will be removed
+    a = "this code will be scrubbed"
+    ### END HIDDEN TESTS
+
+You can use the scrub comment as follows::
+
+    abc-feedback assignment-name --scrub
 
 Command-line Arguments
 ======================
@@ -30,7 +48,7 @@ Command-line Arguments
 Run ``abc-feedback -h`` to see details of command line parameters::
 
   $ abc-feedback -h
-  usage: abc-feedback [-h] [--github] assignment
+  usage: abc-feedback [-h] [--github] [--scrub] assignment-name
 
   Copies feedback reports to local student repositories and (optionally) pushes to github. Assumes files
   are in the directory course_materials/feedback/student/assignment. Copies all files in the source
@@ -43,3 +61,4 @@ Run ``abc-feedback -h`` to see details of command line parameters::
     -h, --help  show this help message and exit
     --github    Also pushes files to student repositories on GitHub (default = False; only copies files to
                 local repos)
+    --scrub     Cleans out hidden tests from notebooks when used.


### PR DESCRIPTION
This implemented a `--scrub` option on `abc-feedback` which will clean the html files removing hidden tests before pushing to student repos.

It seems to be working as i just used it for assignment 4. no tests added here yet. 
@nkorinek this is the feature that we will add to the PR that you're working on to build out tests. let's coordinate on getting this integrated with your pr when you open it. 

this will have to address #290  #238 