### PR TITLE
make default roster name classroom_roster.csv

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,9 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [Unreleased]
 ------------
+- Update the default config to use ``classroom_roster.csv`` which is the default GH classroom filename (@lwasser, #297)
 - Add ``scrub`` argument to abc-feedback to clean hidden tests from html (@lwasser, #290, #238)
+
 
 [0.1.6]
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,6 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Update the default config to use ``classroom_roster.csv`` which is the default GH classroom filename (@lwasser, #297)
 - Add ``scrub`` argument to abc-feedback to clean hidden tests from html (@lwasser, #290, #238)
 
-
 [0.1.6]
 ------------
 - Add files_to_ignore to skip moving certain files (@lwasser, #172, #278)

--- a/abcclassroom/example-data/config.yml
+++ b/abcclassroom/example-data/config.yml
@@ -1,16 +1,16 @@
 
 # The GitHub organization to host your GitHub classroom
 # Create a new organization on GitHub and change this to the name you gave it
-organization: earth-analytics-edu
+organization: your-organization-name
 
 # Absolute path to the course directory. If you ran abc-quickstart, this was
 # set up for you
-course_directory: /Users/karen/awesome-course
+course_directory: /Users/your-user-name/awesome-course
 
 # Path to the course roster (list of students downloaded from
 # github classroom). If the roster is in the course_directory, simply enter
 # the filename (otherwise, enter the path relative to the course_directory).
-roster: roster.csv
+roster: classroom_roster.csv
 
 # Path to the directory that holds your course materials. If you are using
 # nbgrader, this is the top-level nbgrader directory. Path assumed to be


### PR DESCRIPTION
this addresses #297 which makes the default roster name `classroom_roster.csv `which aligns with what github classroom provides upon download.