### PR TITLE
Move clone into a stand alone function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [unreleased]
 ------------
+- Move clone into a stand alone package function (@lwasser, #319)
 - Add fixtures to conftest for universal abc setup (@lwasser, #316)
 - Fix CI to force mac to build on python 3.8 and fix linux matrix / tox versions (@lwasser, #303)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [unreleased]
 ------------
+- Add fixtures to conftest for universal abc setup (@lwasser, #316)
 - Fix CI to force mac to build on python 3.8 and fix linux matrix / tox versions (@lwasser, #303)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and this project adheres to
 `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+[unreleased]
+------------
+- Fix CI to force mac to build on python 3.8 and fix linux matrix / tox versions (@lwasser, #303)
 
-[Unreleased]
+
+[0.1.7]
 ------------
 - Update the default config to use ``classroom_roster.csv`` which is the default GH classroom filename (@lwasser, #297)
 - Setup windows testing using github actions (@lwasser, #300)

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -87,6 +87,7 @@ def clone_repos(assignment_name, skip_existing):
     clone_dir = cf.get_config_option(config, "clone_dir", True)
     organization = cf.get_config_option(config, "organization", True)
     materials_dir = cf.get_config_option(config, "course_materials", False)
+    print(config)
 
     if materials_dir is None:
         print(
@@ -128,7 +129,9 @@ def clone_repos(assignment_name, skip_existing):
                 print(" {}".format(r))
 
     except FileNotFoundError as err:
-        print("Cannot find roster file: {}".format(roster_filename))
+        raise FileNotFoundError(
+            "Cannot find roster file: {}".format(roster_filename)
+        )
         print(err)
 
 

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -87,7 +87,6 @@ def clone_repos(assignment_name, skip_existing):
     clone_dir = cf.get_config_option(config, "clone_dir", True)
     organization = cf.get_config_option(config, "organization", True)
     materials_dir = cf.get_config_option(config, "course_materials", False)
-    print(config)
 
     if materials_dir is None:
         print(
@@ -109,7 +108,6 @@ def clone_repos(assignment_name, skip_existing):
             try:
                 for row in reader:
                     student = row["github_username"]
-                    print(row)
                     # Expected columns: identifier,github_username,
                     # github_id,name
                     repo = "{}-{}".format(assignment_name, student)

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -95,15 +95,13 @@ def clone_repos(assignment_name, skip_existing):
             "repositories. I can't copy any assignment files to a "
             "course_materials directory."
         )
-    # This is a really large try block and makes it hard to figure out where
-    # things fail. perhaps break out into a few sub try / excepts?
+
     try:
         # Create the assignment subdirectory path and ensure it exists
         Path(course_dir, clone_dir, assignment_name).mkdir(exist_ok=True)
         missing_repos = []
         missing_student_gh = []
-        # If it can't find the roster file you'll get a FileNotFoundError
-        # Also what happens if the roster is not in the correct format??
+
         with open(roster_filename, newline="") as csvfile:
             reader = csv.DictReader(csvfile)
             try:
@@ -139,6 +137,9 @@ def clone_repos(assignment_name, skip_existing):
         if len(missing_repos) == 0 and len(missing_student_gh) == 0:
             print("Great! All repos were successfully cloned!")
         else:
+            # Two potential points of failure 1. github repo doesn't exist or
+            # 2. missing gh username. Here the message is clear about what
+            # is wrong
             if len(missing_repos) > 0:
                 print("Could not clone or update the following repos: ")
                 for r in missing_repos:

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -106,21 +106,32 @@ def clone_repos(assignment_name, skip_existing):
         # Also what happens if the roster is not in the correct format??
         with open(roster_filename, newline="") as csvfile:
             reader = csv.DictReader(csvfile)
-            for row in reader:
-                student = row["github_username"]
-                # Expected columns: identifier,github_username,github_id,name
-                repo = "{}-{}".format(assignment_name, student)
-                try:
-                    clone_or_update_repo(
-                        organization,
-                        repo,
-                        Path(clone_dir, assignment_name),
-                        skip_existing,
-                    )
-                    if materials_dir is not None:
-                        copy_assignment_files(config, student, assignment_name)
-                except RuntimeError:
-                    missing.append(repo)
+            try:
+                for row in reader:
+                    student = row["github_username"]
+                    print(row)
+                    # Expected columns: identifier,github_username,
+                    # github_id,name
+                    repo = "{}-{}".format(assignment_name, student)
+                    try:
+                        clone_or_update_repo(
+                            organization,
+                            repo,
+                            Path(clone_dir, assignment_name),
+                            skip_existing,
+                        )
+                        if materials_dir is not None:
+                            copy_assignment_files(
+                                config, student, assignment_name
+                            )
+                    except RuntimeError:
+                        missing.append(repo)
+            except KeyError as ke:
+                raise KeyError(
+                    "Oops! Please check your roster file to "
+                    "ensure is has the correct "
+                    "headers. {}".format(ke)
+                )
         if len(missing) == 0:
             print("All successful; no missing repos")
         else:

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -78,7 +78,13 @@ def clone_repo(organization, repo, dest_dir):
     """Clone `repository` from `org` into a sub-directory in `directory`.
     Assumes you have ssh keys setup for github (rather than using GitHub API
     token)."""
+    # If ssh  it not setup correctly -  or however we want to authenticate,
+    # we need a
+    # friendly message about that
+    # We should add some message about what is being cloned here - the  url
+    # works
     url = "git@github.com:{}/{}.git".format(organization, repo)
+    print("cloning:", url)
     _call_git("-C", dest_dir, "clone", url)
 
 

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -43,7 +43,7 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
     This is the implementation of the abc-quickstart script; it is called
     directly from main.
     """
-    # Making sure the sample configuration file is where it's supposed to be.
+    # Make sure the sample configuration file is where it's supposed to be.
     try:
         config_path = path_to_example("config.yml")
     except FileNotFoundError as err:
@@ -54,7 +54,7 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
                 err
             )
         )
-    # Assigning the custom folder name if applicable
+    # Assign the custom folder name if applicable
     if " " in course_name:
         raise ValueError(
             """Spaces not allowed in custom course name: {}. Please use
@@ -66,7 +66,7 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
         working_dir = os.getcwd()
     main_dir = Path(working_dir, course_name)
 
-    # Check if the main_dir doesn't exist already
+    # Check if the main_dir exists
     if main_dir.is_dir():
         if force:
             rmtree(main_dir)
@@ -78,27 +78,43 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
                 Consider using a different course name, deleting the
                 existing directory, or running quikstart with the -f flag to
                 force overwrite the existing directory.""".format(
-                    course_name
+                    main_dir
                 )
             )
-    # make the main course directory and copy the config file there
+    # Make the main course directory and copy the config file there
     main_dir.mkdir()
     copy(config_path, main_dir)
 
-    # now we can use config functions to read / write config
+    # Use config functions to read / write config
+    # TODO: Can't we just copy the sample config - why are we rewriting it
+    #  here?
     config = cf.get_config(main_dir)
     config["course_directory"] = str(main_dir)
     cf.write_config(config, main_dir)
     clone_dir = cf.get_config_option(config, "clone_dir")
     template_dir = cf.get_config_option(config, "template_dir")
 
-    # make the required subdirectories
+    # Make the required subdirectories
     Path(main_dir, clone_dir).mkdir()
     Path(main_dir, template_dir).mkdir()
 
-    # create the extra_files directory in the main_dir
+    # Create the extra_files directory in the main_dir & copy files
     extra_path = path_to_example("extra_files")
     copytree(extra_path, Path(main_dir, "extra_files"))
+
+    # Copy the sample roster over to the new quickstart dir
+    # TODO make sure the name of this file matches the default config name
+    try:
+        sample_roster = path_to_example("sample_roster.csv")
+        copy(sample_roster, Path(main_dir))
+    except FileNotFoundError as err:
+        print(
+            """Sample config.yml configuration file cannot be located at {},
+        please ensure abc-classroom has been installed
+        correctly""".format(
+                err
+            )
+        )
 
     print(
         """

--- a/abcclassroom/tests/conftest.py
+++ b/abcclassroom/tests/conftest.py
@@ -2,7 +2,14 @@
 Fixtures to set up basic directory structure, including config and
 extra files, for tests.
 """
+
+import os
+from pathlib import Path
+
 import pytest
+
+from abcclassroom.quickstart import create_dir_struct
+import abcclassroom.config as cf
 
 
 @pytest.fixture
@@ -17,3 +24,46 @@ def default_config():
         "files_to_ignore": [".DS_Store", ".ipynb_checkpoints"],
     }
     return config
+
+
+@pytest.fixture
+def config_file(default_config, tmp_path):
+    """Writes the config to a file in tmp_path"""
+    cf.write_config(default_config, tmp_path)
+
+
+@pytest.fixture
+def sample_course_structure(tmp_path):
+    """Creates the quickstart demo directory setup for testing"""
+    course_name = "demo-course"
+    # Run quickstart
+    create_dir_struct(course_name, working_dir=tmp_path)
+    # Get config and reset course path - for some reason if the path isn't
+    # set here it grabs the config in abc-classroom (tim's old config)
+    path_to_course = Path(tmp_path, course_name)
+    a_config = cf.get_config(configpath=path_to_course)
+    a_config["course_directory"] = path_to_course
+    os.chdir(path_to_course)
+    return course_name, a_config
+
+
+@pytest.fixture
+def course_structure_assignment(sample_course_structure, tmp_path):
+    """Creates an assignment within the default course structure directory
+    with several files including system files that we want to ignore."""
+    course_name, a_config = sample_course_structure
+    assignment_name = "demo_assignment1"
+    release_path = Path(
+        tmp_path,
+        course_name,
+        a_config["course_materials"],
+        "release",
+        assignment_name,
+    )
+    release_path.mkdir(parents=True)
+    release_path.joinpath("file1.txt").touch()
+    release_path.joinpath("file2.ipynb").touch()
+    release_path.joinpath(".DS_Store").touch()
+    print(release_path)
+
+    return a_config, assignment_name, release_path

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -1,7 +1,6 @@
 # Tests for clone script
 
 import pytest
-import os
 from pathlib import Path
 
 import abcclassroom.clone as abcclone
@@ -48,23 +47,29 @@ def test_roster_missing(sample_course_structure, tmp_path):
         abcclone.clone_repos(assignment_name, skip_existing=False)
 
 
-# TODO: Test what happens when the roster exists but has the incorrect format
 def test_roster_wrong_format(sample_course_structure, tmp_path):
-    """Test that when the roster is missing things fail gracefully."""
+    """Test that when the roster is missing a correct header fail
+    gracefully."""
 
     course_name, config = sample_course_structure
     assignment_name = "test_assignment"
-    # config = cf.get_config()
+
     path_to_course = Path(config["course_directory"])
     # Mess up the roster file
-    path_to_course.joinpath("classroom_roster.csv").touch()
+    roster_path = path_to_course.joinpath("classroom_roster.csv")
+    roster_path.touch()
+    roster_path.write_text(
+        "identifier,githubb_username,github_id,name \n"
+        "student-id,student-gh-name,student-gh-id,"
+        "student-name"
+    )
 
-    # I'm not sure why this actually runs
-    abcclone.clone_repos(assignment_name, skip_existing=False)
-    print(path_to_course)
-    print(os.listdir(path_to_course))
-    print(config["roster"])
+    # Still returning a keyerror
+    with pytest.raises(KeyError, match="Oops! Please check your roster file"):
+        abcclone.clone_repos(assignment_name, skip_existing=False)
 
+
+# TODO: Test that when the roster is empty it fails gracefully
 
 # test_clone_no_local_repo(default_config, tmp_path, monkeypatch):
 # need to mock up github api object for this

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -32,6 +32,12 @@ def test_files(default_config, tmp_path):
             Path(assignment_path, f).touch()
 
 
+# TODO: Test that the correct message is returned when no course_materials dir
+# exists in the config
+
+# TODO: Test what happens when the roster doesn'exist
+
+
 # test_clone_no_local_repo(default_config, tmp_path, monkeypatch):
 # need to mock up github api object for this
 

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -37,6 +37,9 @@ def test_files(default_config, tmp_path):
 # TODO: Test that the correct message is returned when no course_materials dir
 # exists in the config
 
+# TODO: Test what happens when a student is listed but not repo for that
+#  student is found (so the gh username is missing or misspelled
+
 
 def test_roster_missing(sample_course_structure, tmp_path):
     """Test that when the roster is missing things fail gracefully."""
@@ -47,7 +50,30 @@ def test_roster_missing(sample_course_structure, tmp_path):
         abcclone.clone_repos(assignment_name, skip_existing=False)
 
 
-def test_roster_wrong_format(sample_course_structure, tmp_path):
+def test_roster_missing_github_name(sample_course_structure, capsys):
+    """Test that when the roster is missing a student gh username."""
+
+    course_name, config = sample_course_structure
+    assignment_name = "test_assignment"
+
+    path_to_course = Path(config["course_directory"])
+    # Mess up the roster file
+    roster_path = path_to_course.joinpath("classroom_roster.csv")
+    roster_path.touch()
+    roster_path.write_text(
+        '"identifier","github_username","github_id","name" \n'
+        '"student-id","","student-gh-id",'
+        '"student-name1" \n "student-id","","",'
+        '"student-name2"'
+    )
+    abcclone.clone_repos(assignment_name, skip_existing=False)
+
+    captured = capsys.readouterr()
+    expected_string = "Oops! The following students are missing github"
+    assert expected_string in captured.out
+
+
+def test_roster_wrong_format(sample_course_structure):
     """Test that when the roster is missing a correct header fail
     gracefully."""
 
@@ -59,12 +85,11 @@ def test_roster_wrong_format(sample_course_structure, tmp_path):
     roster_path = path_to_course.joinpath("classroom_roster.csv")
     roster_path.touch()
     roster_path.write_text(
-        "identifier,githubb_username,github_id,name \n"
-        "student-id,student-gh-name,student-gh-id,"
-        "student-name"
+        '"identifier","githubb_username","github_id","name" \n'
+        '"student-id","student-gh-name","student-gh-id",'
+        '"student-name"'
     )
 
-    # Still returning a keyerror
     with pytest.raises(KeyError, match="Oops! Please check your roster file"):
         abcclone.clone_repos(assignment_name, skip_existing=False)
 

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -12,7 +12,7 @@ test_data = {
     "files": ["nb1.ipynb", "nb2.ipynb", "junk.csv"],
 }
 
-# We might have a version of this in conftest
+# TODO: We might have a version of this fixture in conftest
 
 
 @pytest.fixture

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -1,6 +1,7 @@
 # Tests for clone script
 
 import pytest
+import os
 from pathlib import Path
 
 import abcclassroom.clone as abcclone
@@ -11,6 +12,8 @@ test_data = {
     "students": ["bert", "alana"],
     "files": ["nb1.ipynb", "nb2.ipynb", "junk.csv"],
 }
+
+# We might have a version of this in conftest
 
 
 @pytest.fixture
@@ -35,7 +38,32 @@ def test_files(default_config, tmp_path):
 # TODO: Test that the correct message is returned when no course_materials dir
 # exists in the config
 
-# TODO: Test what happens when the roster doesn'exist
+
+def test_roster_missing(sample_course_structure, tmp_path):
+    """Test that when the roster is missing things fail gracefully."""
+    # config = sample_course_structure
+    assignment_name = "test_assignment"
+
+    with pytest.raises(FileNotFoundError, match="Cannot find roster file"):
+        abcclone.clone_repos(assignment_name, skip_existing=False)
+
+
+# TODO: Test what happens when the roster exists but has the incorrect format
+def test_roster_wrong_format(sample_course_structure, tmp_path):
+    """Test that when the roster is missing things fail gracefully."""
+
+    course_name, config = sample_course_structure
+    assignment_name = "test_assignment"
+    # config = cf.get_config()
+    path_to_course = Path(config["course_directory"])
+    # Mess up the roster file
+    path_to_course.joinpath("classroom_roster.csv").touch()
+
+    # I'm not sure why this actually runs
+    abcclone.clone_repos(assignment_name, skip_existing=False)
+    print(path_to_course)
+    print(os.listdir(path_to_course))
+    print(config["roster"])
 
 
 # test_clone_no_local_repo(default_config, tmp_path, monkeypatch):


### PR DESCRIPTION
fixes #318 
This pr only moves the clone cli function into it's own function so we can also clone directly using python.

There are many TODO's in the clone module.

there are no tests and checks to ensure

1. that the roster exists
2. that the repo exists
3. when clone doesn't work you have no idea why
4. there are no tests really in general of all of the functionality.

i won't work on all of the above now, just am moving things over into a python-ready structure right now. 