### PR TITLE
rename default template repo dir name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [unreleased]
 ------------
+- Default template_repos dir rather than assignment_repos (@lwasser, #327)
 - Overhaul fixtures, support moving  different type of files & fix codecov ci (@lwasser, #273, #172)
 
 [0.1.8]

--- a/abcclassroom/example-data/config.yml
+++ b/abcclassroom/example-data/config.yml
@@ -28,7 +28,7 @@ clone_dir: cloned_repos
 # the parent directories should be a git repo. Assumed to be relative to
 # course_dir unless you enter an absolute path (i.e. starting with '/' on
 # Linux or OS X or with 'C:' on Windows).
-template_dir: assignment_repos
+template_dir: template_repos
 
 # A list of files that you do not want to be copied from your assignment
 # release directory to the github template repo. These may be system files


### PR DESCRIPTION
closes #309 

This is a very minor change to the default config setting for the default template repo directory name. shouldn't impact much but i think it's a better default name.