### PR TITLE
Check ssh git setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Make new repositories use 'main' instead of 'master' as the default branch (@kcranston, #326)
 - Fix manged abc-quickstart success message (@kcranston, #367)
 - Refactor the main-to-master branch renaming for better error handling and usability (@kcranston, #363)
+- Check for working ssh keys before git commands that connect to github (@kcranston, #366)
 
 [0.1.8]
 ------------

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -48,7 +48,7 @@ def init():
         github.check_git_ssh()
         print("Access to GitHub via SSH seems to be configured correctly")
     except RuntimeError:
-        raise
+        pass
 
 
 def clone():

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -35,8 +35,20 @@ def init():
     GitHub authentication yaml file, and if there isn't, create a valid file.
     """
 
-    print("Setting up GitHub API access")
+    print("Step 1: Setting up GitHub API access")
     github.get_access_token()
+
+    print(
+        """Step 2: Checking ssh access to GitHub. If you have not
+        connected before, you will see a message with an RSA fingerprint
+        asking if you want to continue connecting. Enter yes.
+        """
+    )
+    try:
+        github.check_git_ssh()
+        print("Access to GitHub via SSH seems to be configured correctly")
+    except RuntimeError:
+        raise
 
 
 def clone():

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -102,7 +102,15 @@ def copy_feedback_files(assignment_name, push_to_github=False, scrub=False):
                     ),
                 )
                 if push_to_github:
-                    github.push_to_github(destination_dir)
+                    try:
+                        github.push_to_github(destination_dir)
+                    except RuntimeError as e:
+                        print(e)
+                        print(
+                            "Push to GitHub failed for repo {}".format(
+                                destination_dir
+                            )
+                        )
 
     except FileNotFoundError as err:
         print("Missing file or directory:")

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -109,6 +109,15 @@ def check_git_ssh():
                 )
             )
             raise RuntimeError(subprocess_out)
+    except FileNotFoundError as e:
+        # we get here if ssh is not installed. The error message is
+        # [Errno 2] No such file or directory: 'ssh'
+        print(e)
+        if "No such file or directory: 'ssh'" in str(e):
+            print(
+                """Did not find `ssh` command. Make sure that open-ssh
+                is installed on your operating system."""
+            )
 
 
 def _get_authenticated_user(token):

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -65,8 +65,6 @@ def check_git_ssh():
     """Tests that ssh access to GitHub is set up correctly on the users
     computer.
 
-    Returns the github username.
-
     Throws a RuntimeError if setup is not working.
     """
     cmd = ["ssh", "-T", "git@github.com"]
@@ -88,9 +86,7 @@ def check_git_ssh():
         if err.startswith("Hi"):
             # if everything set up correctly, the ssh test returns output
             # starting with 'Hi username!'
-            message = err.split()
-            username = message[1].replace("!", "")
-            return username
+            pass
         elif err.startswith("Permission"):
             # if no key, or permissions on key incorrect, the output
             # starts with 'Permission denied'
@@ -102,6 +98,13 @@ def check_git_ssh():
                 )
             )
             raise RuntimeError(err)
+        elif err.startswith("Warning: Permanently"):
+            # if the user has set up ssh keys, but hasn't logged in yet,
+            # they will need to verify the RSA fingerprint
+            # If they do so, the message is 'Warning: Permanently
+            # added 'github.com' (RSA) to the list of known hosts.'
+            print(err)
+            pass
         else:
             # just in case there are other message in edge cases
             print("Unknown error checking ssh access to git")

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -228,16 +228,19 @@ def remote_repo_exists(org, repository, token=None):
 
 def clone_repo(organization, repo, dest_dir):
     """Clone `repository` from `org` into a sub-directory in `directory`.
-    Assumes you have ssh keys setup for github (rather than using GitHub API
-    token)."""
-    # If ssh  it not setup correctly -  or however we want to authenticate,
-    # we need a
-    # friendly message about that
-    # We should add some message about what is being cloned here - the  url
-    # works
-    url = "git@github.com:{}/{}.git".format(organization, repo)
-    print("cloning:", url)
-    _call_git("-C", dest_dir, "clone", url)
+
+    Raises RuntimeError if ssh keys not set up correctly, or if git clone
+    fails for other reasons.
+    """
+
+    try:
+        # first, check that local git set up with ssh keys for github
+        check_git_ssh()
+        url = "git@github.com:{}/{}.git".format(organization, repo)
+        print("cloning:", url)
+        _call_git("-C", dest_dir, "clone", url)
+    except RuntimeError as e:
+        raise e
 
 
 def create_repo(org, repository, token):

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -373,8 +373,10 @@ def _master_branch_to_main(dir):
 
 
 def push_to_github(directory, branch="main"):
-    """Push `branch` back to GitHub"""
+    """Push `branch` of the repository in `directory` back to GitHub"""
     try:
+        # first, check that local git set up with ssh keys for github
+        check_git_ssh()
         _call_git(
             "push", "--set-upstream", "origin", branch, directory=directory
         )

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -80,19 +80,19 @@ def check_git_ssh():
         # We ALWAYS will get here, because that subprocess call returns
         # a non-zero exit code whether ssh access is set up correctly or
         # not. Must check output.
-        err = e.stderr
-        if not err:
-            err = e.stdout
-        if err.startswith("Hi"):
+        subprocess_out = e.stderr
+        if not subprocess_out:
+            subprocess_out = e.stdout
+        if subprocess_out.startswith("Hi"):
             # if everything set up correctly, the ssh test returns output
             # starting with 'Hi username!'
             pass
-        elif err.startswith("Warning: Permanently"):
+        elif subprocess_out.startswith("Warning: Permanently"):
             # if the user has set up ssh keys, but hasn't logged in yet,
             # they will need to verify the RSA fingerprint
             # If they do so, the message is 'Warning: Permanently
             # added 'github.com' (RSA) to the list of known hosts.'
-            print(err)
+            print(subprocess_out)
             pass
         else:
             # possible reasons to get here include 1. no ssh key set up;
@@ -100,7 +100,7 @@ def check_git_ssh():
             # identification changed. We print the error message for
             # the user and point them to github documentation for help.
             print("Encountered this error checking ssh access to git:")
-            print(err)
+            print(subprocess_out)
             docURL = "https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh"  # noqa
             print(
                 """Your ssh access to github is not set up correctly; see
@@ -108,7 +108,7 @@ def check_git_ssh():
                     docURL
                 )
             )
-            raise RuntimeError(err)
+            raise RuntimeError(subprocess_out)
 
 
 def _get_authenticated_user(token):

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -87,17 +87,6 @@ def check_git_ssh():
             # if everything set up correctly, the ssh test returns output
             # starting with 'Hi username!'
             pass
-        elif err.startswith("Permission"):
-            # if no key, or permissions on key incorrect, the output
-            # starts with 'Permission denied'
-            docURL = "https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh"  # noqa
-            print(
-                """Your ssh access to github is not set up correctly;
-            see {}.""".format(
-                    docURL
-                )
-            )
-            raise RuntimeError(err)
         elif err.startswith("Warning: Permanently"):
             # if the user has set up ssh keys, but hasn't logged in yet,
             # they will need to verify the RSA fingerprint
@@ -106,8 +95,19 @@ def check_git_ssh():
             print(err)
             pass
         else:
-            # just in case there are other message in edge cases
-            print("Unknown error checking ssh access to git")
+            # possible reasons to get here include 1. no ssh key set up;
+            # 2. ssh key has incorrect permissions; 3. remote host
+            # identification changed. We print the error message for
+            # the user and point them to github documentation for help.
+            print("Encountered this error checking ssh access to git:")
+            print(err)
+            docURL = "https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh"  # noqa
+            print(
+                """Your ssh access to github is not set up correctly;
+            see {}.""".format(
+                    docURL
+                )
+            )
             raise RuntimeError(err)
 
 

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -387,6 +387,8 @@ def push_to_github(directory, branch="main"):
 def pull_from_github(directory, branch="master"):
     """Pull `branch` of local repo in `directory` from GitHub"""
     try:
+        # first, check that local git set up with ssh keys for github
+        check_git_ssh()
         _call_git("pull", "origin", branch, directory=directory)
     except RuntimeError as e:
         raise e

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -103,8 +103,8 @@ def check_git_ssh():
             print(err)
             docURL = "https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh"  # noqa
             print(
-                """Your ssh access to github is not set up correctly;
-            see {}.""".format(
+                """Your ssh access to github is not set up correctly; see
+            {}.""".format(
                     docURL
                 )
             )

--- a/abcclassroom/template.py
+++ b/abcclassroom/template.py
@@ -118,8 +118,8 @@ def create_or_update_remote(
     template_repo_path, organization, repo_name, token
 ):
     """
-    Push template repo to github creating a new repository or update the
-    repo's contents
+    Push template repo to GitHub. If remote does not yet exist, creates it
+    before pushing.
 
     Parameters
     ----------
@@ -154,7 +154,7 @@ def create_or_update_remote(
         print(
             """Push to github failed. This is usually because there are
             changes on the remote that you do not have locally. Here is the
-            github error:"""
+            git error:"""
         )
         print(e)
 


### PR DESCRIPTION
This creates a new function for checking that ssh keys are set up correctly for use with git commands that talk to github. 

Needs more testing before merge. I have done some local testing, but need to set up a course directory / assignments / students, etc on my local machine for more in-depth checking. If @lwasser or @nkorinek get to this before me - great! The affected abc scripts are: 

* `abc-init`
* `abc-clone`, 
* `abc-new-template` with `--github` option 
* `abc-update-template`
* `abc-feedback` with --github option

There is no pytest coverage, because getting tests that use git with ssh keys to run in Actions is non-trivial (and seems out of scope for this issue, but worth doing, see this milestone https://github.com/earthlab/abc-classroom/milestone/6 ).

Closes #366 