### PR TITLE
Set default branch to main for git pull function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Make new repositories use 'main' instead of 'master' as the default branch (@kcranston, #326)
 - Fix manged abc-quickstart success message (@kcranston, #367)
 - Refactor the main-to-master branch renaming for better error handling and usability (@kcranston, #363)
+- Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
 
 [0.1.8]
 ------------

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -39,9 +39,17 @@ def clone_or_update_repo(organization, repo, clone_dir, skip_existing):
                 )
             )
             return
-        gh.pull_from_github(destination_dir)
+        try:
+            gh.pull_from_github(destination_dir)
+        except RuntimeError as e:
+            print("Error pulling repository {}".format(destination_dir))
+            print(e)
     else:
-        gh.clone_repo(organization, repo, clone_dir)
+        try:
+            gh.clone_repo(organization, repo, clone_dir)
+        except RuntimeError as e:
+            print("Error cloning repository {}".format(repo))
+            print(e)
 
 
 def clone_student_repos(args):

--- a/abcclassroom/github.py
+++ b/abcclassroom/github.py
@@ -332,7 +332,7 @@ def push_to_github(directory, branch="main"):
         raise e
 
 
-def pull_from_github(directory, branch="master"):
+def pull_from_github(directory, branch="main"):
     """Pull `branch` of local repo in `directory` from GitHub"""
     try:
         _call_git("pull", "origin", branch, directory=directory)


### PR DESCRIPTION
This fixes a bug where the default branch for the git pull function was still set to `master` rather than `main`. Also added some exception handling, because the failure was silent. 

Closes #376 