### PR TITLE
Roster management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Check for working ssh keys before git commands that connect to github (@kcranston, #366)
 - Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
 - Use classroom_roster.csv consistently for roster filename (@kcranston, #383)
+- abc-clone and abc-feedback use same roster handling and print full path if FileNotFoundError (@kcranston, #384)
 
 [0.1.8]
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,11 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 
 [unreleased]
 ------------
-
+- Check for working ssh keys before git commands that connect to github (@kcranston, #366)
+- Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
+- Use classroom_roster.csv consistently for roster filename (@kcranston, #383)
+- abc-clone and abc-feedback use same roster handling and print full path if FileNotFoundError (@kcranston, #384)
+- new abc-roster script that creates nbgrader-formatted roster from GitHub Classroom roster (@kcranston, #59)
 
 [0.1.9]
 ------------
@@ -18,11 +22,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Make new repositories use 'main' instead of 'master' as the default branch (@kcranston, #326)
 - Fix manged abc-quickstart success message (@kcranston, #367)
 - Refactor the main-to-master branch renaming for better error handling and usability (@kcranston, #363)
-- Check for working ssh keys before git commands that connect to github (@kcranston, #366)
-- Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
-- Use classroom_roster.csv consistently for roster filename (@kcranston, #383)
-- abc-clone and abc-feedback use same roster handling and print full path if FileNotFoundError (@kcranston, #384)
-- new abc-roster script that creates nbgrader-formatted roster from GitHub Classroom roster (@kcranston, #59)
+
 
 [0.1.8]
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Refactor the main-to-master branch renaming for better error handling and usability (@kcranston, #363)
 - Check for working ssh keys before git commands that connect to github (@kcranston, #366)
 - Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
+- Use classroom_roster.csv consistently for roster filename (@kcranston, #383)
 
 [0.1.8]
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 - Fix bug where git pull method was still trying to use master as the default branch rather than main (@kcranston, #376)
 - Use classroom_roster.csv consistently for roster filename (@kcranston, #383)
 - abc-clone and abc-feedback use same roster handling and print full path if FileNotFoundError (@kcranston, #384)
+- new abc-roster script that creates nbgrader-formatted roster from GitHub Classroom roster (@kcranston, #59)
 
 [0.1.8]
 ------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,31 +61,41 @@ To run only the subset of the tests in (for example) `singlefile.py`, use:
 
     $ pytest abcclassroom/tests/singlefile.py
 
-Deploying	
-=========	
+Building the docs
+=================
 
-A reminder for the maintainers on how to deploy.	
-Make sure all your changes are committed, then run::	
+To build the docs locally (from the root directory of the repo)::
 
-    $ bumpversion patch # possible: major / minor / patch	
+    $ make docs -B
 
-This will increment the version according to a major release (e.g., 0.1.0 to	
-1.0.0), a minor release (e.g., 0.1.0 to 0.2.0), or a patch (e.g., 0.1.0 to	
-0.1.1), following the guidelines for semantic versioning: https://semver.org/.	
+You can view the local docs in your browser by opening the file
+`docs/_build/html/index.html`.
+
+Deploying
+=========
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed, then run::
+
+    $ bumpversion patch # possible: major / minor / patch
+
+This will increment the version according to a major release (e.g., 0.1.0 to
+1.0.0), a minor release (e.g., 0.1.0 to 0.2.0), or a patch (e.g., 0.1.0 to
+0.1.1), following the guidelines for semantic versioning: https://semver.org/.
 
 
-Bumpversion updates the version number throughout the	
-package, and generates a git commit along with an associated git tag for the	
-new version.	
-For more on bumpversion, see: https://github.com/peritus/bumpversion	
+Bumpversion updates the version number throughout the
+package, and generates a git commit along with an associated git tag for the
+new version.
+For more on bumpversion, see: https://github.com/peritus/bumpversion
 
 To deploy abc-classroom, push the commit and the version tags::
 
-    $ git push	
-    $ git push --tags	
+    $ git push
+    $ git push --tags
 
-Travis will then deploy to PyPI if the build succeeds.	
-Travis will only deploy to PyPI on tagged commits, so remember to push the tags.	
+Travis will then deploy to PyPI if the build succeeds.
+Travis will only deploy to PyPI on tagged commits, so remember to push the tags.
 Once that is done, create a release on GitHub for the new version.
 
 Optional: Install nbgrader

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -8,6 +8,7 @@ from . import github
 
 from .quickstart import create_dir_struct
 from .clone import clone_student_repos
+from .roster import create_roster
 
 
 def quickstart():
@@ -157,23 +158,31 @@ def new_template():
 
 def roster():
     """Given a csv file containing a roster downloaded from Github
-    Classroom, creates an new file by adding an `id` column that contains
-    the github username. New file named `abc-classroom` unless alternate
-    name specified. The new roster file can be
-    used as the roster for both abc-classroom and nbgrader. Overwrites
-    existing roster file with same name.
+    Classroom, creates new roster for use by nbgrader.
+    Two operations:
+    1. Adds an `id` column that contains the github username.
+    2. Attempts to split the `name` column into two new columns,
+    first_name and last_name.
+    Saves the new file in the course_materials directory using the
+    filename `nbgrader_roster.csv` unless you specify an alternate name.
+    Fails if output file already exists.
     """
-    parser = argparse.ArgumentParser(description=update_template.__doc__)
+    parser = argparse.ArgumentParser(description=roster.__doc__)
     parser.add_argument(
         "github_roster",
         help="""A csv file in the format downloaded from GitHub Classroom.
         Must contain github_username column.""",
     )
     parser.add_argument(
-        "--filename",
-        default="abc_roster.csv",
-        help="""The name of the new roster file, default is abc_roster.csv""",
+        "-o",
+        "--outfile",
+        default="nbgrader_roster.csv",
+        help="""The name of the new roster file. Default is
+        nbgrader_roster.csv. Created in the course_materials directory,
+        as defined in config.yml""",
     )
+    args = parser.parse_args()
+    create_roster(args.github_roster, args.outfile)
 
 
 def update_template():

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -181,8 +181,15 @@ def roster():
         nbgrader_roster.csv. Created in the course_materials directory,
         as defined in config.yml""",
     )
+    parser.add_argument(
+        "-n",
+        "--namecolumn",
+        default="name",
+        help="""The column to split to make the new columns
+        first_name and last_name. Default is 'name'.""",
+    )
     args = parser.parse_args()
-    create_roster(args.github_roster, args.outfile)
+    create_roster(args.github_roster, args.outfile, args.namecolumn)
 
 
 def update_template():

--- a/abcclassroom/__main__.py
+++ b/abcclassroom/__main__.py
@@ -155,6 +155,27 @@ def new_template():
     template.new_update_template(args)
 
 
+def roster():
+    """Given a csv file containing a roster downloaded from Github
+    Classroom, creates an new file by adding an `id` column that contains
+    the github username. New file named `abc-classroom` unless alternate
+    name specified. The new roster file can be
+    used as the roster for both abc-classroom and nbgrader. Overwrites
+    existing roster file with same name.
+    """
+    parser = argparse.ArgumentParser(description=update_template.__doc__)
+    parser.add_argument(
+        "github_roster",
+        help="""A csv file in the format downloaded from GitHub Classroom.
+        Must contain github_username column.""",
+    )
+    parser.add_argument(
+        "--filename",
+        default="abc_roster.csv",
+        help="""The name of the new roster file, default is abc_roster.csv""",
+    )
+
+
 def update_template():
     """
     Updates an existing assignment template repository: update / add new and

--- a/abcclassroom/clone.py
+++ b/abcclassroom/clone.py
@@ -176,8 +176,9 @@ def clone_repos(assignment_name, skip_existing=False, no_submitted=True):
                     print(" {}".format(astudent))
 
     except FileNotFoundError as err:
+        abs_roster_path = Path(roster_filename).resolve()
         raise FileNotFoundError(
-            "Cannot find roster file: {}".format(roster_filename)
+            "Cannot find roster file: {}".format(abs_roster_path)
         )
         print(err)
 

--- a/abcclassroom/example-data/classroom_roster.csv
+++ b/abcclassroom/example-data/classroom_roster.csv
@@ -1,0 +1,3 @@
+"identifier","github_username","github_id","name"
+"Firstname1 Lastname1","username1","12312312",""
+"Firstname2 Lastname2","username2","45464564","Optionalfirstname Optionallastname"

--- a/abcclassroom/example-data/readme.md
+++ b/abcclassroom/example-data/readme.md
@@ -1,20 +1,23 @@
 # Example data for abc-classroom
 
-This directory contains two files and a directory.
+This directory contains two files (in addition to this readme) and a
+directory.
+
+**Do not modify the files in example-data** - they are used by `abc-classroom`
+when setting up a new course.
 
 ## config.yml
 
-**Do not modify this file in this location**
+The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. If you aren't using `abc-quickstart` and you want to create your own config, make a copy, place the copy in your course directory, and modify the copy.
 
-The template config file. When you run `abc-quickstart`, it copies this config into the new course directory and updates the `course_directory` key. Because this file is used by **abc-classroom**, do not modify this file directly. If you aren't using `abc-quickstart` and you want to create your own config, make a copy, place the copy in your course directory, and modify the copy.
+## classroom_roster.csv
 
-## sample_roster.csv
-
-A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is not used by **abc-classroom** directly. It is only provided here for reference.
+A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is copied by not used by `abc-quickstart` into the course materials directory as a sample of the roster
+format.
 
 ## extra_files
 
-This directory gets copied to your `course_materials` directory. Then, any files
-placed in `course_materials/extra_files` will be copied into new assignment
-template directories. By default, this directory contains a `.gitignore` file and
-a `readme.md`.
+This directory gets copied to your `course_materials` directory as part of
+`abc-quickstart`. After that, any additional files that you place in
+`course_materials/extra_files` will be copied into new assignment
+template directories. By default, this directory contains a `.gitignore` file and a `readme.md`.

--- a/abcclassroom/example-data/readme.md
+++ b/abcclassroom/example-data/readme.md
@@ -12,8 +12,9 @@ The template config file. When you run `abc-quickstart`, it copies this config i
 
 ## classroom_roster.csv
 
-A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is copied by not used by `abc-quickstart` into the course materials directory as a sample of the roster
-format.
+A sample course roster (matching the format downloaded from [GitHub classroom](https://classroom.github.com/)). This file is copied by
+`abc-quickstart` into the course materials directory as a sample of
+the roster format.
 
 ## extra_files
 

--- a/abcclassroom/example-data/sample_roster.csv
+++ b/abcclassroom/example-data/sample_roster.csv
@@ -1,3 +1,0 @@
-"identifier","github_username","github_id","name"
-"Firstname Lastname","username","12312312",""
-"Anotherfirstname Anotherlastname","username","45464564","Optionalfirstname Optionallastname"

--- a/abcclassroom/feedback.py
+++ b/abcclassroom/feedback.py
@@ -113,8 +113,11 @@ def copy_feedback_files(assignment_name, push_to_github=False, scrub=False):
                         )
 
     except FileNotFoundError as err:
-        print("Missing file or directory:")
-        print(" ", err)
+        abs_roster_path = Path(roster_filename).resolve()
+        raise FileNotFoundError(
+            "Cannot find roster file: {}".format(abs_roster_path)
+        )
+        print(err)
 
 
 def copy_feedback(args):

--- a/abcclassroom/quickstart.py
+++ b/abcclassroom/quickstart.py
@@ -105,8 +105,8 @@ def create_dir_struct(course_name="abc_course", force=False, working_dir=None):
     # Copy the sample roster over to the new quickstart dir
     # TODO make sure the name of this file matches the default config name
     try:
-        sample_roster = path_to_example("sample_roster.csv")
-        copy(sample_roster, Path(main_dir))
+        classroom_roster = path_to_example("classroom_roster.csv")
+        copy(classroom_roster, Path(main_dir))
     except FileNotFoundError as err:
         print(
             """Sample config.yml configuration file cannot be located at {},

--- a/abcclassroom/roster.py
+++ b/abcclassroom/roster.py
@@ -1,0 +1,97 @@
+"""
+abc-classroom.roster
+====================
+
+"""
+
+import csv
+import pprint
+from pathlib import Path
+
+from . import config as cf
+
+
+def create_roster(input_file, output_file="nbgrader_roster.csv"):
+    """Given a roster file downloaded from GitHub Classroom, creates
+    a roster file suitable for use with abc-classroom and nbgrader.
+
+    Parameters
+    ----------
+    input_file : string
+        Path to the GitHub Classroom roster
+    output_file: string
+        Name of the output file. Default is abc_roster.csv
+
+    """
+    # create path to input file
+    classroom_roster_path = Path(input_file)
+
+    # get the materials_dir from the config and set the path of the
+    # output file
+    config = cf.get_config()
+    materials_dir = cf.get_config_option(config, "course_materials", False)
+
+    # if the course materials dir does not exist, return
+    if not Path(materials_dir).is_dir():
+        print(
+            "Course materials directory '{}' as specified in config "
+            "file does not exist. Please create "
+            "it and then re-run abc-roster".format(materials_dir)
+        )
+        return
+
+    output_file_path = Path(materials_dir, output_file)
+
+    # if the output file exists, return
+    if output_file_path.exists():
+        print(
+            "Output file '{}' already exists. Please delete, rename, "
+            "or move this file (or specify a different output file "
+            "with the -o or --output flag) "
+            "before re-running abc-roster.".format(output_file_path)
+        )
+        return
+
+    try:
+        with open(classroom_roster_path, newline="") as csv_input, open(
+            output_file_path, "w", newline=""
+        ) as csv_output:
+            reader = csv.DictReader(csv_input)
+            columns = reader.fieldnames
+            print(columns)
+            columns.append("id")
+            columns.append("first_name")
+            columns.append("last_name")
+            print(columns)
+            writer = csv.DictWriter(csv_output, fieldnames=columns)
+            writer.writeheader()
+            for row in reader:
+                newrow = row
+                ghname = row["github_username"]
+                row["id"] = ghname
+                if "name" in row:
+                    name = row["name"]
+                    # split into two parts based on final space in field
+                    # assume first part is first name and second part is
+                    # last name
+                    twonames = name.rsplit(" ", 1)
+                    try:
+                        newrow["first_name"] = twonames[0]
+                    except IndexError:
+                        newrow["first_name"] = ""
+                    try:
+                        newrow["last_name"] = twonames[1]
+                    except IndexError:
+                        newrow["last_name"] = ""
+                pprint.pprint(newrow)
+
+    except FileNotFoundError as err:
+        # prints the error [Errno 2] No such file or directory:
+        # 'classroom_roster_path'
+        print(err)
+    except KeyError as ke:
+        # prints error Error: Input file does not contain required column
+        # 'github_username'
+        print(
+            "Error: Input file does not contain required column {}".format(ke)
+        )

--- a/abcclassroom/tests/test_clone.py
+++ b/abcclassroom/tests/test_clone.py
@@ -36,7 +36,9 @@ def test_roster_missing(sample_course_structure, tmp_path):
     """Test that when the roster is missing things fail gracefully."""
     # config = sample_course_structure
     assignment_name = "test_assignment"
-
+    course_name, config = sample_course_structure
+    roster_path = Path(config["course_directory"], "classroom_roster.csv")
+    roster_path.unlink()
     with pytest.raises(FileNotFoundError, match="Cannot find roster file"):
         abcclone.clone_repos(assignment_name, skip_existing=False)
 

--- a/docs/api/abcclassroom.roster.rst
+++ b/docs/api/abcclassroom.roster.rst
@@ -1,0 +1,4 @@
+.. automodule:: abcclassroom.roster
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/abcclassroom.rst
+++ b/docs/api/abcclassroom.rst
@@ -20,6 +20,7 @@ Submodules
    abcclassroom.notebook
    abcclassroom.ok
    abcclassroom.quickstart
+   abcclassroom.roster
    abcclassroom.scrub_feedback
    abcclassroom.template
    abcclassroom.utils

--- a/docs/get-started/classroom-roster.rst
+++ b/docs/get-started/classroom-roster.rst
@@ -1,0 +1,68 @@
+Managing the classroom roster
+-----------------------------
+
+The classroom roster is a csv file that contains information about the students
+in your class. `abc-classroom` uses the roster file when:
+
+* cloning student assignment repositories with `abc-clone`
+* pushing feedback to student repositories with `abc-feedback`
+
+Location of the roster
+======================
+The location of the classroom roster is defined in the configuration file,
+`config.yml`. By default, this is `classroom_roster.csv` in the course directory. See :doc:`Configuration <configuration>` for information on setting the name and location of the roster.
+
+Roster formats
+==============
+
+The roster formats for GitHub Classroom and nbgrader are slightly different
+and you cannot directly use a GitHub Classroom roster as input for nbgrader.
+
+The nbgrader roster requires an "id" column with a unique identifier for
+each student. It is also helpful to have the first name and last name
+of each student in the nbgrader roster. Then, you can identify students
+in the web interface based on real names rather than GitHub usernames.
+
+The GitHub Classroom roster contains an "identifier" column,
+but this can contain a name, email address, or github username (depending
+on the student profile, whether they have accepted an assignment, etc).
+
+If you aren't using nbgrader, you can use the GitHub Classroom roster
+with `abc-classroom`. The only piece of information that `abc-classroom`
+requires is a single column for each
+student, labelled `github_username`, that contains the
+GitHub username for each student.
+
+Converting a roster to nbgrader format
+======================================
+
+To convert a Classroom roster to nbgrader format, we want to copy the
+"github_username" column in the former to an "id" column in the latter. We
+can also split the "name" column into first_name and last_name.
+
+Download the GitHub Classroom roster using the download link on the
+Students tab on your Classroom course page. This file will contain the
+following columns::
+
+  identifier, github_username, github_id, name
+
+Make sure you have a course_materials directory defined in ``config.yml``
+and that the directory exists.
+
+Run ``abc-roster``::
+
+  $ abc-roster classroom_roster.csv
+
+Which will create a new file, ``course_materials/nbgrader_roster.csv`` with
+the following columns::
+
+  identifier,github_username,github_id,name,id,first_name,last_name
+
+You can specify a different output filename with the ``-o`` option.
+
+``abc-roster`` creates the first and last name columns by splitting
+the "name" column on the last whitespace (i.e. "Kermit the Frog" becomes
+"Kermit the", "Frog"). You can specify a different
+column to split using the ``-n`` option.
+
+Run ``abc-roster -h`` for details.

--- a/docs/get-started/configuration.rst
+++ b/docs/get-started/configuration.rst
@@ -1,2 +1,12 @@
 Configuration
 -------------
+
+roster
+======
+
+Enter the path to the classroom roster. If you enter a bare filename,
+`abc-classroom` will look in the course directory for the file. If your
+roster file is somewhere else, you can enter a full path to the file,
+e.g. `/home/user/directory/filename.csv`. 
+
+Default: `roster: classroom_roster.csv`

--- a/docs/get-started/configuration.rst
+++ b/docs/get-started/configuration.rst
@@ -1,6 +1,10 @@
 Configuration
 -------------
 
+The settings for abc-classroom are in a configuration file. By default, this
+file is called "config.yml" and is located in the course directory. If you
+used ```abc-quickstart``, this file is created for you.
+
 roster
 ======
 
@@ -10,10 +14,7 @@ roster file is somewhere else, you can enter a full path to the file,
 e.g. `/home/user/directory/filename.csv`. 
 
 Default: `roster: classroom_roster.csv`
-=======
-The settings for abc-classroom are in a configuration file. By default, this
-file is called "config.yml" and is located in the course directory. If you
-used ```abc-quickstart``, this file is created for you.
+
 
 Files_to_ignore
 ===============

--- a/docs/get-started/index.rst
+++ b/docs/get-started/index.rst
@@ -17,7 +17,8 @@ to understand the **abc-classroom** workflow.
    :maxdepth: 2
    :caption: Get Started with ABC-Classroom
 
+   ABC-Classroom Overview <overview>
    Installation & Github Authentication <get-started>
    create-course
-   ABC-Classroom Overview <overview>
+   Managing the Student Roster <classroom-roster>
    configuration

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "abc-update-template = abcclassroom.__main__:update_template",
             "abc-clone = abcclassroom.__main__:clone",
             "abc-feedback = abcclassroom.__main__:feedback",
+            "abc-roster = abcclassroom.__main__:roster",
         ]
     },
     url="https://github.com/earthlab/abc-classroom",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={
         "abcclassroom": [
             "example-data/readme.md",
-            "example-data/sample_roster.csv",
+            "example-data/classroom_roster.csv",
             "example-data/config.yml",
             "example-data/extra_files/README.md",
             "example-data/extra_files/.gitignore",


### PR DESCRIPTION
Adds a new script, `abc-roster` that creates a nbgrader-formatted roster from a GitHub Classsroom roster. Creates an `id` column from the `github_username` column, and creates `first_name`, `last_name` from `name`. Saves new file as `course_materials/nbgrader_roster.csv`. This addresses #59 (finally!).

Run `abc-roster -h` for usage. 

Also changes code and files to use `classroom_roster.csv` consistently in example files and config, #383 

Also adds better error handing for missing rosters, #384 (noting that I could not reproduce the error in this issue, so I am not 100% sure it it solved). 
