### PR TITLE
update pre commit to ensure the right v of black runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 20.8b1
+  rev: 21.10b0
   hooks:
   - id: black
     language_version: python3


### PR DESCRIPTION
This is just a baby PR that will ensure black - the right version - runs via the pre commit hook. ci was breaking because of this mismatch.